### PR TITLE
docs(sphinx): render version + add home & emojis to sidebar

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,11 @@
+/* Version label rendered by docs/_templates/layout.html under the project
+   title in the sidebar. sphinx_rtd_theme >=3.0 no longer ships a `.version`
+   style, so we provide one matching the prior look. */
+.wy-side-nav-search > .version {
+    color: rgba(255, 255, 255, 0.45);
+    font-size: 90%;
+    margin-top: -0.4045em;
+    margin-bottom: 0.809em;
+    font-weight: normal;
+    display: block;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,32 @@
+{# sphinx_rtd_theme >=3.0 dropped the `display_version` switch from its sidebar
+   template. We re-add a small version line under the project title by
+   overriding the upstream `sidebartitle` block. The body mirrors the upstream
+   block (sphinx_rtd_theme/layout.html) so we can slot in the `.version` div
+   between the project link and the searchbox. #}
+{% extends "!layout.html" %}
+
+{% block sidebartitle %}
+  {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+  {%- set _root_doc = root_doc|default(master_doc) %}
+  <a href="{{ pathto(_root_doc) }}"{% if not theme_logo_only %} class="icon icon-home"{% endif %}>
+    {% if not theme_logo_only %}{{ project }}{% endif %}
+    {%- if logo or logo_url %}
+      <img src="{{ _logo_url }}" class="logo" alt="{{ _('Logo') }}"/>
+    {%- endif %}
+  </a>
+
+  {%- if version %}
+    <div class="version">{{ version }}</div>
+  {%- endif %}
+
+  {%- if READTHEDOCS or DEBUG %}
+    {%- if theme_version_selector or theme_language_selector %}
+      <div class="switch-menus">
+        <div class="version-switch"></div>
+        <div class="language-switch"></div>
+      </div>
+    {%- endif %}
+  {%- endif %}
+
+  {%- include "searchbox.html" %}
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,13 +61,13 @@ html_static_path = ['_static']
 html_js_files = [
     'custom.js',    # custom JS file
 ]
+html_css_files = [
+    'custom.css',   # custom CSS file
+]
 
-# Show the package version in the sidebar header (under the project title).
-# `release` (set above) is the source; `display_version=True` is the
-# sphinx_rtd_theme switch that renders it.
-html_theme_options = {
-    'display_version': True,
-}
+# The package version is rendered under the project title in the sidebar via
+# `_templates/layout.html`, which overrides sphinx_rtd_theme's `sidebartitle`
+# block. The theme's old `display_version` option was removed in 3.0.
 
 # nbsphinx configuration
 nbsphinx_execute = 'never'  # Set to 'always' if you want to execute the notebooks during the build process

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,10 +33,11 @@ Check out the following sub-pages:
 .. toctree::
    :maxdepth: 1
 
-   Readme file <readme>
-   Updates <updates>
-   API reference <source/modules>
-   Example notebooks <notebooks>
+   🏠 Home <self>
+   📖 Readme file <readme>
+   📝 Updates <updates>
+   ⚙️ API reference <source/modules>
+   📓 Example notebooks <notebooks>
 
 
 Citing


### PR DESCRIPTION
## Summary
- Render package version in the sidebar via a `sidebartitle` template override (the previous `display_version` flag is a no-op in `sphinx_rtd_theme >= 3.0`).
- Add a `Home <self>` toctree entry and prefix each sidebar item with an emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)