### PR TITLE
WebAPI: support OpenAI gpt-5 family

### DIFF
--- a/folktexts/classifier/base.py
+++ b/folktexts/classifier/base.py
@@ -385,8 +385,12 @@ class LLMClassifier(BaseEstimator, ClassifierMixin, ABC):
         context_size = self._inference_kwargs["context_size"]
         num_batches = math.ceil(len(df) / batch_size)
 
-        # Get questions to ask
-        q = self.task.question
+        # Get questions to ask. Backends may override the task's question at
+        # `__init__` time via `_active_question` — e.g. `WebAPILLMClassifier`
+        # swaps a decimal-prefill numeric QA for a percentage variant on the
+        # gpt-5 family (see `_enable_numeric_percentage_mode`). Falls back to
+        # the task's default question when no override is set.
+        q = getattr(self, "_active_question", None) or self.task.question
         questions = [q]
         if self.correct_order_bias:
             if isinstance(q, DirectNumericQA):

--- a/folktexts/classifier/base.py
+++ b/folktexts/classifier/base.py
@@ -385,12 +385,13 @@ class LLMClassifier(BaseEstimator, ClassifierMixin, ABC):
         context_size = self._inference_kwargs["context_size"]
         num_batches = math.ceil(len(df) / batch_size)
 
-        # Get questions to ask. Backends may override the task's question at
-        # `__init__` time via `_active_question` — e.g. `WebAPILLMClassifier`
-        # swaps a decimal-prefill numeric QA for a percentage variant on the
-        # gpt-5 family (see `_enable_numeric_percentage_mode`). Falls back to
-        # the task's default question when no override is set.
-        q = getattr(self, "_active_question", None) or self.task.question
+        # Read the active question from `prompt_config.suffix.question`
+        # rather than `task.question`: backends may swap it at `__init__` time
+        # (e.g. `WebAPILLMClassifier` reframes numeric QA as an integer
+        # percentage for the gpt-5 family; see `_enable_numeric_percentage_mode`).
+        # `prompt_config.suffix.question` defaults to `task.question`, so this
+        # is a no-op for the standard construction path.
+        q = self.prompt_config.suffix.question
         questions = [q]
         if self.correct_order_bias:
             if isinstance(q, DirectNumericQA):

--- a/folktexts/classifier/web_api_classifier.py
+++ b/folktexts/classifier/web_api_classifier.py
@@ -2,16 +2,19 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 import re
 import time
+from functools import partial
 from typing import Callable
 
 import numpy as np
 import pandas as pd
 
 from folktexts.llm_utils import decode_topk_logprobs_to_risk_estimate
+from folktexts.prompting import encode_row_prompt as default_encode_row_prompt
 from folktexts.qa_interface import ChainOfThoughtQA, DirectNumericQA, MultipleChoiceQA
 from folktexts.task import TaskMetadata
 
@@ -32,12 +35,19 @@ _OPENAI_MODEL_FAMILY_QUIRKS: dict[str, dict] = {
         "top_logprobs_max": 5,
         "max_tokens_overhead": 3,
         "force_reasoning_none": True,
+        # Under `reasoning_effort='none'`, gpt-5 collapses the standard
+        # `Answer (between 0 and 1): 0.` prefill to `'0.0'` regardless of
+        # input (AUC ~chance on ACSIncome). Reframing as an integer
+        # percentage (0-100, no prefill) unblocks the full digit range and
+        # restores discrimination (probe → HIGH-income '92', LOW '12').
+        "numeric_percentage_mode": True,
     },
 }
 _DEFAULT_FAMILY_QUIRKS: dict = {
     "top_logprobs_max": 20,
     "max_tokens_overhead": 0,
     "force_reasoning_none": False,
+    "numeric_percentage_mode": False,
 }
 
 
@@ -138,8 +148,58 @@ class WebAPILLMClassifier(LLMClassifier):
         self._warned_unsupported_params: set[str] = set()
         self._family_quirks = _resolve_family_quirks(self.model_name)
 
+        # Some model families need the numeric QA prompt reframed as an
+        # integer percentage rather than the default `Answer: 0.<digits>`
+        # prefill (see `_OPENAI_MODEL_FAMILY_QUIRKS`). Swap the current
+        # prompt config's question if it is a `DirectNumericQA` and the
+        # user did not already set `percentage=True`.
+        if (
+            self._family_quirks.get("numeric_percentage_mode")
+            and isinstance(self._prompt_config.suffix.question, DirectNumericQA)
+            and not self._prompt_config.suffix.question.percentage
+        ):
+            self._enable_numeric_percentage_mode()
+
         # Set litellm logger level to WARNING
         logging.getLogger("LiteLLM").setLevel(logging.WARNING)
+
+    def _enable_numeric_percentage_mode(self) -> None:
+        """Swap the current numeric QA for a `percentage=True` variant.
+
+        Use `num_forward_passes=15`: gpt-5 under `reasoning_effort='none'`
+        wraps the answer in markdown (`'**Probability (0-100): 28**'`), so
+        the digit lands ~8-10 tokens in. Fewer passes truncate the response
+        before the digit. The percentage decoder then locates the highest-
+        confidence answer position from the returned top-K logprobs.
+
+        The swapped question is stored on `_active_question` — that's what
+        the base classifier consults at prediction time (see
+        `LLMClassifier.compute_risk_estimates_for_dataframe`). We also
+        propagate it into `_prompt_config` so any code path that inspects
+        the classifier's config sees a consistent view.
+        """
+        original_q = self._prompt_config.suffix.question
+        new_q = dataclasses.replace(
+            original_q, percentage=True, num_forward_passes=15
+        )
+        self._active_question = new_q
+        new_suffix = dataclasses.replace(self._prompt_config.suffix, question=new_q)
+        self._prompt_config = dataclasses.replace(
+            self._prompt_config, suffix=new_suffix
+        )
+        # `_encode_row` was built via `partial(...)` capturing the OLD
+        # prompt_config; rebuild it against the swapped one.
+        self._encode_row = partial(
+            default_encode_row_prompt,
+            task=self.task,
+            prompt_config=self._prompt_config,
+        )
+        logging.info(
+            f"Enabled numeric-percentage mode for model '{self.model_name}': "
+            f"prompt now asks for an integer percentage (0-100) instead of "
+            f"the decimal `0.<digits>` prefill (workaround for "
+            f"reasoning_effort='none' degeneration)."
+        )
 
     @staticmethod
     def check_webAPI_deps() -> bool:
@@ -360,8 +420,16 @@ class WebAPILLMClassifier(LLMClassifier):
             question=question,
         )
 
-        # Sanity check numeric answers based on global model response:
-        if isinstance(question, DirectNumericQA):
+        # Sanity check numeric answers based on global model response.
+        # Skip for percentage mode: the model wraps the digit in markdown
+        # (e.g. `'**Probability (0-100): 28**'`), so the naive `re.match`
+        # here yields no match and the anchored parse below returns a
+        # non-answer literal like `100` from the `(0-100)` range label.
+        # The percentage decoder already recovers the correct answer.
+        if (
+            isinstance(question, DirectNumericQA)
+            and not getattr(question, "percentage", False)
+        ):
             try:
                 numeric_response = re.match(
                     r"[-+]?\d*\.\d+|\d+", response_message

--- a/folktexts/classifier/web_api_classifier.py
+++ b/folktexts/classifier/web_api_classifier.py
@@ -162,6 +162,7 @@ class WebAPILLMClassifier(LLMClassifier):
             )
         self.supported_params = set(supported_params)
         self._warned_unsupported_params: set[str] = set()
+        self._warned_unvalidated_reasoning = False
         self._family_quirks = _resolve_family_quirks(self.model_name)
 
         # Some model families need the numeric QA prompt reframed as an
@@ -189,11 +190,10 @@ class WebAPILLMClassifier(LLMClassifier):
         before the digit. The percentage decoder then locates the highest-
         confidence answer position from the returned top-K logprobs.
 
-        The swapped question is stored on `_active_question` — that's what
-        the base classifier consults at prediction time (see
-        `LLMClassifier.compute_risk_estimates_for_dataframe`). We also
-        propagate it into `_prompt_config` so any code path that inspects
-        the classifier's config sees a consistent view.
+        The swapped question lives in `_prompt_config.suffix.question`; the
+        base classifier reads it from there at prediction time (see
+        `LLMClassifier.compute_risk_estimates_for_dataframe`), and the
+        rebuilt `_encode_row` partial ensures encoding sees the same swap.
 
         The default numeric system prompt is also replaced with one that
         explicitly names the required answer format (mirroring what CoT
@@ -209,7 +209,6 @@ class WebAPILLMClassifier(LLMClassifier):
         new_q = dataclasses.replace(
             original_q, percentage=True, num_forward_passes=15
         )
-        self._active_question = new_q
         new_suffix = dataclasses.replace(self._prompt_config.suffix, question=new_q)
 
         # Replace the numeric system prompt ONLY if the current one is the
@@ -352,6 +351,34 @@ class WebAPILLMClassifier(LLMClassifier):
                 top_logprobs=self._family_quirks["top_logprobs_max"],
             )
 
+        # Warn once when MCQ/Numeric is run against a reasoning-capable model
+        # whose WebAPI quirks haven't been explicitly validated. Reasoning
+        # models tend to preamble/wrap the answer, exhausting the tight
+        # `max_tokens` budget used by token-probability decoding — even with
+        # `logprobs` support the numbers can silently collapse to chance.
+        # Only fires for MCQ/Numeric (CoT is robust) and when the model was
+        # NOT matched by an explicit entry in `_OPENAI_MODEL_FAMILY_QUIRKS`.
+        if (
+            not isinstance(question, ChainOfThoughtQA)
+            and "reasoning_effort" in self.supported_params
+            and self._family_quirks is _DEFAULT_FAMILY_QUIRKS
+            and not self._warned_unvalidated_reasoning
+        ):
+            self._warned_unvalidated_reasoning = True
+            logging.warning(
+                f"Model '{self.model_name}' advertises `reasoning_effort` "
+                f"support (likely a reasoning/thinking model) but has no "
+                f"validated entry in `_OPENAI_MODEL_FAMILY_QUIRKS`. "
+                f"Multiple-choice / numeric prompting on reasoning models "
+                f"can degrade to chance-level AUC (models preamble or wrap "
+                f"the answer in markdown, exhausting the small `max_tokens` "
+                f"budget). If results look wrong, use chain-of-thought "
+                f"prompting (`--cot-prompting`) instead, or add an entry to "
+                f"`_OPENAI_MODEL_FAMILY_QUIRKS` (see the gpt-5 entry for "
+                f"reference: `numeric_percentage_mode`, `force_reasoning_none`, "
+                f"`max_tokens_overhead`, `top_logprobs_max`)."
+            )
+
         # gpt-5.x refuses `logprobs` requests unless reasoning_effort='none'
         # is set — pass it only for MCQ/numeric (CoT reads free-form text and
         # benefits from the model's default reasoning budget).
@@ -473,10 +500,7 @@ class WebAPILLMClassifier(LLMClassifier):
         # here yields no match and the anchored parse below returns a
         # non-answer literal like `100` from the `(0-100)` range label.
         # The percentage decoder already recovers the correct answer.
-        if (
-            isinstance(question, DirectNumericQA)
-            and not getattr(question, "percentage", False)
-        ):
+        if isinstance(question, DirectNumericQA) and not question.percentage:
             try:
                 numeric_response = re.match(
                     r"[-+]?\d*\.\d+|\d+", response_message

--- a/folktexts/classifier/web_api_classifier.py
+++ b/folktexts/classifier/web_api_classifier.py
@@ -22,18 +22,21 @@ from .base import LLMClassifier
 # combination-level), not key-level. Verified live against gpt-5.4-{mini,nano}:
 #   - `top_logprobs > 5` → BadRequestError.
 #   - Any logprobs request without `reasoning_effort='none'` → UnsupportedParams.
-#   - Single-token completions with `max_tokens < 4` → "could not finish".
+#   - A ~3-token hidden preamble consumes from `max_completion_tokens` even
+#     when `reasoning_effort='none'` (`reasoning_tokens=0`) — a 1-token MCQ
+#     request needs `max_tokens=4`, a 5-token numeric one needs `max_tokens=8`,
+#     or the completion is truncated before any visible content is emitted.
 # Extend as further families exhibit similar caps.
 _OPENAI_MODEL_FAMILY_QUIRKS: dict[str, dict] = {
     "gpt-5": {
         "top_logprobs_max": 5,
-        "min_max_tokens": 4,
+        "max_tokens_overhead": 3,
         "force_reasoning_none": True,
     },
 }
 _DEFAULT_FAMILY_QUIRKS: dict = {
     "top_logprobs_max": 20,
-    "min_max_tokens": 1,
+    "max_tokens_overhead": 0,
     "force_reasoning_none": False,
 }
 
@@ -222,7 +225,7 @@ class WebAPILLMClassifier(LLMClassifier):
             num_forward_passes = 1
             api_call_params = dict(
                 temperature=0,
-                max_tokens=max(num_forward_passes, self._family_quirks["min_max_tokens"]),
+                max_tokens=num_forward_passes + self._family_quirks["max_tokens_overhead"],
                 stream=False,
                 seed=self.seed,
                 logprobs=True,
@@ -235,7 +238,7 @@ class WebAPILLMClassifier(LLMClassifier):
             num_forward_passes = question.num_forward_passes + 2
             api_call_params = dict(
                 temperature=0,
-                max_tokens=max(num_forward_passes, self._family_quirks["min_max_tokens"]),
+                max_tokens=num_forward_passes + self._family_quirks["max_tokens_overhead"],
                 stream=False,
                 seed=self.seed,
                 logprobs=True,

--- a/folktexts/classifier/web_api_classifier.py
+++ b/folktexts/classifier/web_api_classifier.py
@@ -14,11 +14,27 @@ import numpy as np
 import pandas as pd
 
 from folktexts.llm_utils import decode_topk_logprobs_to_risk_estimate
+from folktexts.prompting import VarySystemPrompt
 from folktexts.prompting import encode_row_prompt as default_encode_row_prompt
 from folktexts.qa_interface import ChainOfThoughtQA, DirectNumericQA, MultipleChoiceQA
 from folktexts.task import TaskMetadata
 
 from .base import LLMClassifier
+
+# System prompt used when `numeric_percentage_mode` is auto-enabled. Reasoning
+# models under `reasoning_effort='none'` (gpt-5.x) do not reliably continue the
+# user-turn prefill `'Probability (0-100): '` — they preamble or wrap in
+# markdown, and the fixed `max_tokens` budget then truncates the response
+# before any digit is emitted. Instructing the model to reply with ONLY the
+# format line (no preamble, no reasoning) short-circuits the preamble and
+# gives the anchor-based decoder a predictable `probability<...>:` span.
+NUMERIC_PERCENTAGE_SYSTEM_PROMPT = (
+    "You are a helpful assistant. You provide numeric probability estimates "
+    "based on the information provided. Reply with ONLY the single line "
+    "'Probability (0-100): X%' where X is an integer between 0 and 100. "
+    "Do NOT include any preamble, reasoning, restatement of the question, "
+    "or any other text — just that single line."
+)
 
 # OpenAI reasoning-model families impose per-family quirks that litellm's
 # `get_supported_openai_params` can't surface — they are value-level (or
@@ -164,7 +180,8 @@ class WebAPILLMClassifier(LLMClassifier):
         logging.getLogger("LiteLLM").setLevel(logging.WARNING)
 
     def _enable_numeric_percentage_mode(self) -> None:
-        """Swap the current numeric QA for a `percentage=True` variant.
+        """Swap the current numeric QA for a `percentage=True` variant and
+        install an explicit answer-format instruction on the system prompt.
 
         Use `num_forward_passes=15`: gpt-5 under `reasoning_effort='none'`
         wraps the answer in markdown (`'**Probability (0-100): 28**'`), so
@@ -177,6 +194,16 @@ class WebAPILLMClassifier(LLMClassifier):
         `LLMClassifier.compute_risk_estimates_for_dataframe`). We also
         propagate it into `_prompt_config` so any code path that inspects
         the classifier's config sees a consistent view.
+
+        The default numeric system prompt is also replaced with one that
+        explicitly names the required answer format (mirroring what CoT
+        already does). Reasoning models don't reliably continue the
+        user-turn prefill `'Probability (0-100): '` — they preamble or wrap
+        in markdown — so an explicit instruction reduces zero-fallback
+        rows. Any user-supplied `system_prompt` (via `PromptConfig` /
+        `--system-prompt`) is preserved: the swap only fires when the
+        current system prompt is the numeric QA's own default, so callers
+        who deliberately override it are never silently clobbered.
         """
         original_q = self._prompt_config.suffix.question
         new_q = dataclasses.replace(
@@ -184,9 +211,27 @@ class WebAPILLMClassifier(LLMClassifier):
         )
         self._active_question = new_q
         new_suffix = dataclasses.replace(self._prompt_config.suffix, question=new_q)
-        self._prompt_config = dataclasses.replace(
-            self._prompt_config, suffix=new_suffix
+
+        # Replace the numeric system prompt ONLY if the current one is the
+        # QA subclass default (i.e. the caller didn't set --system-prompt).
+        current_sys = self._prompt_config.system_prompt
+        is_default_sys = (
+            current_sys is not None
+            and current_sys.system_prompt == type(original_q).default_system_prompt
         )
+        if is_default_sys:
+            new_system_prompt = VarySystemPrompt(
+                system_prompt=NUMERIC_PERCENTAGE_SYSTEM_PROMPT
+            )
+            self._prompt_config = dataclasses.replace(
+                self._prompt_config,
+                suffix=new_suffix,
+                system_prompt=new_system_prompt,
+            )
+        else:
+            self._prompt_config = dataclasses.replace(
+                self._prompt_config, suffix=new_suffix
+            )
         # `_encode_row` was built via `partial(...)` capturing the OLD
         # prompt_config; rebuild it against the swapped one.
         self._encode_row = partial(
@@ -198,7 +243,9 @@ class WebAPILLMClassifier(LLMClassifier):
             f"Enabled numeric-percentage mode for model '{self.model_name}': "
             f"prompt now asks for an integer percentage (0-100) instead of "
             f"the decimal `0.<digits>` prefill (workaround for "
-            f"reasoning_effort='none' degeneration)."
+            f"reasoning_effort='none' degeneration); "
+            f"system prompt {'updated to' if is_default_sys else 'left as user override — '}"
+            f"instruct answer format."
         )
 
     @staticmethod

--- a/folktexts/classifier/web_api_classifier.py
+++ b/folktexts/classifier/web_api_classifier.py
@@ -46,28 +46,33 @@ NUMERIC_PERCENTAGE_SYSTEM_PROMPT = (
 #     request needs `max_tokens=4`, a 5-token numeric one needs `max_tokens=8`,
 #     or the completion is truncated before any visible content is emitted.
 # Extend as further families exhibit similar caps.
-_OPENAI_MODEL_FAMILY_QUIRKS: dict[str, dict] = {
-    "gpt-5": {
-        "top_logprobs_max": 5,
-        "max_tokens_overhead": 3,
-        "force_reasoning_none": True,
-        # Under `reasoning_effort='none'`, gpt-5 collapses the standard
-        # `Answer (between 0 and 1): 0.` prefill to `'0.0'` regardless of
-        # input (AUC ~chance on ACSIncome). Reframing as an integer
-        # percentage (0-100, no prefill) unblocks the full digit range and
-        # restores discrimination (probe → HIGH-income '92', LOW '12').
-        "numeric_percentage_mode": True,
-    },
-}
-_DEFAULT_FAMILY_QUIRKS: dict = {
-    "top_logprobs_max": 20,
-    "max_tokens_overhead": 0,
-    "force_reasoning_none": False,
-    "numeric_percentage_mode": False,
-}
+@dataclasses.dataclass(frozen=True)
+class _WebAPIQuirks:
+    """Per-family value-level API constraints for the WebAPI backend."""
+    top_logprobs_max: int = 20
+    max_tokens_overhead: int = 0
+    force_reasoning_none: bool = False
+    # When True, `WebAPILLMClassifier.__init__` swaps a `DirectNumericQA`
+    # for its `percentage=True` variant: gpt-5 under `reasoning_effort='none'`
+    # collapses the standard `Answer (between 0 and 1): 0.` prefill to
+    # `'0.0'` regardless of input (AUC ~chance on ACSIncome). Reframing as
+    # an integer percentage (0-100, no prefill) unblocks the full digit
+    # range and restores discrimination (probe → HIGH-income '92', LOW '12').
+    numeric_percentage_mode: bool = False
 
 
-def _resolve_family_quirks(model_name: str) -> dict:
+_OPENAI_MODEL_FAMILY_QUIRKS: dict[str, _WebAPIQuirks] = {
+    "gpt-5": _WebAPIQuirks(
+        top_logprobs_max=5,
+        max_tokens_overhead=3,
+        force_reasoning_none=True,
+        numeric_percentage_mode=True,
+    ),
+}
+_DEFAULT_FAMILY_QUIRKS = _WebAPIQuirks()
+
+
+def _resolve_family_quirks(model_name: str) -> _WebAPIQuirks:
     for family, quirks in _OPENAI_MODEL_FAMILY_QUIRKS.items():
         if family in model_name:
             return quirks
@@ -171,7 +176,7 @@ class WebAPILLMClassifier(LLMClassifier):
         # prompt config's question if it is a `DirectNumericQA` and the
         # user did not already set `percentage=True`.
         if (
-            self._family_quirks.get("numeric_percentage_mode")
+            self._family_quirks.numeric_percentage_mode
             and isinstance(self._prompt_config.suffix.question, DirectNumericQA)
             and not self._prompt_config.suffix.question.percentage
         ):
@@ -209,28 +214,22 @@ class WebAPILLMClassifier(LLMClassifier):
         new_q = dataclasses.replace(
             original_q, percentage=True, num_forward_passes=15
         )
-        new_suffix = dataclasses.replace(self._prompt_config.suffix, question=new_q)
-
-        # Replace the numeric system prompt ONLY if the current one is the
-        # QA subclass default (i.e. the caller didn't set --system-prompt).
+        replace_kwargs = {
+            "suffix": dataclasses.replace(self._prompt_config.suffix, question=new_q),
+        }
+        # Replace the numeric system prompt ONLY if the current one is the QA
+        # subclass default (i.e. the caller didn't set --system-prompt): callers
+        # who deliberately override it are never silently clobbered.
         current_sys = self._prompt_config.system_prompt
         is_default_sys = (
             current_sys is not None
             and current_sys.system_prompt == type(original_q).default_system_prompt
         )
         if is_default_sys:
-            new_system_prompt = VarySystemPrompt(
+            replace_kwargs["system_prompt"] = VarySystemPrompt(
                 system_prompt=NUMERIC_PERCENTAGE_SYSTEM_PROMPT
             )
-            self._prompt_config = dataclasses.replace(
-                self._prompt_config,
-                suffix=new_suffix,
-                system_prompt=new_system_prompt,
-            )
-        else:
-            self._prompt_config = dataclasses.replace(
-                self._prompt_config, suffix=new_suffix
-            )
+        self._prompt_config = dataclasses.replace(self._prompt_config, **replace_kwargs)
         # `_encode_row` was built via `partial(...)` capturing the OLD
         # prompt_config; rebuild it against the swapped one.
         self._encode_row = partial(
@@ -238,13 +237,11 @@ class WebAPILLMClassifier(LLMClassifier):
             task=self.task,
             prompt_config=self._prompt_config,
         )
+        sys_note = "system prompt updated" if is_default_sys else "user system prompt preserved"
         logging.info(
-            f"Enabled numeric-percentage mode for model '{self.model_name}': "
-            f"prompt now asks for an integer percentage (0-100) instead of "
-            f"the decimal `0.<digits>` prefill (workaround for "
-            f"reasoning_effort='none' degeneration); "
-            f"system prompt {'updated to' if is_default_sys else 'left as user override — '}"
-            f"instruct answer format."
+            f"Enabled numeric-percentage mode for '{self.model_name}': "
+            f"prompt reframed as integer percentage (0-100) to work around "
+            f"reasoning_effort='none' decimal-prefill degeneration; {sys_note}."
         )
 
     @staticmethod
@@ -304,8 +301,10 @@ class WebAPILLMClassifier(LLMClassifier):
         responses_batch : list[dict]
             The returned JSON responses for each prompt in the batch.
         """
-        # Handle ChainOfThoughtQA with longer text generation
-        if isinstance(question, ChainOfThoughtQA):
+        is_cot = isinstance(question, ChainOfThoughtQA)
+
+        if is_cot:
+            # CoT: free-form text generation, no logprobs.
             api_call_params = dict(
                 temperature=self._resolve_temperature(question),
                 max_tokens=question.max_new_tokens,
@@ -322,95 +321,76 @@ class WebAPILLMClassifier(LLMClassifier):
                     "and provide your final probability estimate. Your response MUST end "
                     "with 'Probability: X%' where X is a number between 0 and 100."
                 )
-        # Adapt number of forward passes for token-probability based methods.
-        # Temperature is always 0 here: MC/numeric decode from the returned
-        # top_logprobs (which OpenAI-style APIs report untempered), so sampling
-        # would only add noise to the multi-pass token trajectory.
-        elif question.num_forward_passes == 1:
-            # Single token answers should require only one forward pass
-            num_forward_passes = 1
-            api_call_params = dict(
-                temperature=0,
-                max_tokens=num_forward_passes + self._family_quirks["max_tokens_overhead"],
-                stream=False,
-                seed=self.seed,
-                logprobs=True,
-                top_logprobs=self._family_quirks["top_logprobs_max"],
-            )
         else:
-            # NOTE: Models often generate "0." instead of directly outputting the fractional part
-            # > Therefore: for multi-token answers, extra forward passes may be required
-            # Add extra tokens for textual prefix, e.g., "The probability is: ..."
-            num_forward_passes = question.num_forward_passes + 2
+            # MCQ / DirectNumericQA: token-probability decoding.
+            # Temperature is always 0: MC/numeric decode from the returned
+            # top_logprobs (which OpenAI-style APIs report untempered), so
+            # sampling would only add noise to the multi-pass trajectory.
+            # For multi-token numeric answers, add 2 extra passes to cover
+            # the "0." (or paraphrase) prefix the model may emit before digits.
+            num_forward_passes = (
+                1 if question.num_forward_passes == 1
+                else question.num_forward_passes + 2
+            )
             api_call_params = dict(
                 temperature=0,
-                max_tokens=num_forward_passes + self._family_quirks["max_tokens_overhead"],
+                max_tokens=num_forward_passes + self._family_quirks.max_tokens_overhead,
                 stream=False,
                 seed=self.seed,
                 logprobs=True,
-                top_logprobs=self._family_quirks["top_logprobs_max"],
+                top_logprobs=self._family_quirks.top_logprobs_max,
             )
 
-        # Warn once when MCQ/Numeric is run against a reasoning-capable model
-        # whose WebAPI quirks haven't been explicitly validated. Reasoning
-        # models tend to preamble/wrap the answer, exhausting the tight
-        # `max_tokens` budget used by token-probability decoding — even with
-        # `logprobs` support the numbers can silently collapse to chance.
-        # Only fires for MCQ/Numeric (CoT is robust) and when the model was
-        # NOT matched by an explicit entry in `_OPENAI_MODEL_FAMILY_QUIRKS`.
-        if (
-            not isinstance(question, ChainOfThoughtQA)
-            and "reasoning_effort" in self.supported_params
-            and self._family_quirks is _DEFAULT_FAMILY_QUIRKS
-            and not self._warned_unvalidated_reasoning
-        ):
-            self._warned_unvalidated_reasoning = True
-            logging.warning(
-                f"Model '{self.model_name}' advertises `reasoning_effort` "
-                f"support (likely a reasoning/thinking model) but has no "
-                f"validated entry in `_OPENAI_MODEL_FAMILY_QUIRKS`. "
-                f"Multiple-choice / numeric prompting on reasoning models "
-                f"can degrade to chance-level AUC (models preamble or wrap "
-                f"the answer in markdown, exhausting the small `max_tokens` "
-                f"budget). If results look wrong, use chain-of-thought "
-                f"prompting (`--cot-prompting`) instead, or add an entry to "
-                f"`_OPENAI_MODEL_FAMILY_QUIRKS` (see the gpt-5 entry for "
-                f"reference: `numeric_percentage_mode`, `force_reasoning_none`, "
-                f"`max_tokens_overhead`, `top_logprobs_max`)."
-            )
+            # Warn once when running against a reasoning-capable model whose
+            # WebAPI quirks haven't been explicitly validated. Reasoning
+            # models preamble/wrap the answer, exhausting the tight
+            # `max_tokens` budget — token-probability decoding can silently
+            # collapse to chance-level AUC. (CoT skips this branch entirely.)
+            if (
+                "reasoning_effort" in self.supported_params
+                and self._family_quirks is _DEFAULT_FAMILY_QUIRKS
+                and not self._warned_unvalidated_reasoning
+            ):
+                self._warned_unvalidated_reasoning = True
+                logging.warning(
+                    f"Model '{self.model_name}' advertises `reasoning_effort` "
+                    f"support (likely a reasoning/thinking model) but has no "
+                    f"validated entry in `_OPENAI_MODEL_FAMILY_QUIRKS`. "
+                    f"Multiple-choice / numeric prompting on reasoning models "
+                    f"can degrade to chance-level AUC (models preamble or wrap "
+                    f"the answer in markdown, exhausting the small `max_tokens` "
+                    f"budget). If results look wrong, use chain-of-thought "
+                    f"prompting (`--cot-prompting`) instead, or add an entry "
+                    f"to `_OPENAI_MODEL_FAMILY_QUIRKS` (see the gpt-5 entry "
+                    f"for reference)."
+                )
 
-        # gpt-5.x refuses `logprobs` requests unless reasoning_effort='none'
-        # is set — pass it only for MCQ/numeric (CoT reads free-form text and
-        # benefits from the model's default reasoning budget).
-        if (
-            not isinstance(question, ChainOfThoughtQA)
-            and self._family_quirks["force_reasoning_none"]
-        ):
-            api_call_params["reasoning_effort"] = "none"
+            # gpt-5.x refuses `logprobs` requests unless reasoning_effort='none'
+            # is set. CoT keeps the model's default reasoning budget.
+            if self._family_quirks.force_reasoning_none:
+                api_call_params["reasoning_effort"] = "none"
 
-        api_call_params = self._filter_supported_params(api_call_params)
-
-        # `logprobs` are load-bearing for token-probability decoding: dropping
-        # them would only fail later, deep inside response decoding. Fail fast
-        # instead (e.g. OpenAI o1/o3 don't support logprobs).
-        if not isinstance(question, ChainOfThoughtQA) and "logprobs" not in api_call_params:
-            raise RuntimeError(
-                f"Model '{self.model_name}' does not support `logprobs`, which "
-                f"are required to decode multiple-choice/numeric risk estimates. "
-                f"Use chain-of-thought prompting (--cot-prompting) instead."
-            )
-
-        # Get system prompt depending on Q&A type (if not already set for ChainOfThoughtQA)
-        if not isinstance(question, ChainOfThoughtQA):
-            # Use the system prompt carried by PromptConfig (always the QA subclass
-            # default unless the caller explicitly cleared it). `None` disables the
-            # system role entirely. Bind unconditionally so it is always defined.
+            # System prompt for MCQ/Numeric: use the one carried by
+            # PromptConfig (the QA subclass default unless explicitly
+            # cleared). `None` disables the system role entirely.
             system_prompt = (
                 self.prompt_config.system_prompt()
                 if self.prompt_config.system_prompt is not None
                 else None
             )
             logging.debug(f"System prompt: {system_prompt}")
+
+        api_call_params = self._filter_supported_params(api_call_params)
+
+        # `logprobs` are load-bearing for token-probability decoding: dropping
+        # them would only fail later, deep inside response decoding. Fail fast
+        # instead (e.g. OpenAI o1/o3 don't support logprobs).
+        if not is_cot and "logprobs" not in api_call_params:
+            raise RuntimeError(
+                f"Model '{self.model_name}' does not support `logprobs`, which "
+                f"are required to decode multiple-choice/numeric risk estimates. "
+                f"Use chain-of-thought prompting (--cot-prompting) instead."
+            )
 
         # Query model for each prompt in the batch
         responses_batch = []

--- a/folktexts/classifier/web_api_classifier.py
+++ b/folktexts/classifier/web_api_classifier.py
@@ -17,6 +17,33 @@ from folktexts.task import TaskMetadata
 
 from .base import LLMClassifier
 
+# OpenAI reasoning-model families impose per-family quirks that litellm's
+# `get_supported_openai_params` can't surface — they are value-level (or
+# combination-level), not key-level. Verified live against gpt-5.4-{mini,nano}:
+#   - `top_logprobs > 5` → BadRequestError.
+#   - Any logprobs request without `reasoning_effort='none'` → UnsupportedParams.
+#   - Single-token completions with `max_tokens < 4` → "could not finish".
+# Extend as further families exhibit similar caps.
+_OPENAI_MODEL_FAMILY_QUIRKS: dict[str, dict] = {
+    "gpt-5": {
+        "top_logprobs_max": 5,
+        "min_max_tokens": 4,
+        "force_reasoning_none": True,
+    },
+}
+_DEFAULT_FAMILY_QUIRKS: dict = {
+    "top_logprobs_max": 20,
+    "min_max_tokens": 1,
+    "force_reasoning_none": False,
+}
+
+
+def _resolve_family_quirks(model_name: str) -> dict:
+    for family, quirks in _OPENAI_MODEL_FAMILY_QUIRKS.items():
+        if family in model_name:
+            return quirks
+    return _DEFAULT_FAMILY_QUIRKS
+
 
 class WebAPILLMClassifier(LLMClassifier):
     """Use an LLM through a web API to produce risk scores."""
@@ -106,6 +133,7 @@ class WebAPILLMClassifier(LLMClassifier):
             )
         self.supported_params = set(supported_params)
         self._warned_unsupported_params: set[str] = set()
+        self._family_quirks = _resolve_family_quirks(self.model_name)
 
         # Set litellm logger level to WARNING
         logging.getLogger("LiteLLM").setLevel(logging.WARNING)
@@ -194,11 +222,11 @@ class WebAPILLMClassifier(LLMClassifier):
             num_forward_passes = 1
             api_call_params = dict(
                 temperature=0,
-                max_tokens=num_forward_passes,
+                max_tokens=max(num_forward_passes, self._family_quirks["min_max_tokens"]),
                 stream=False,
                 seed=self.seed,
                 logprobs=True,
-                top_logprobs=20,
+                top_logprobs=self._family_quirks["top_logprobs_max"],
             )
         else:
             # NOTE: Models often generate "0." instead of directly outputting the fractional part
@@ -207,12 +235,21 @@ class WebAPILLMClassifier(LLMClassifier):
             num_forward_passes = question.num_forward_passes + 2
             api_call_params = dict(
                 temperature=0,
-                max_tokens=num_forward_passes,
+                max_tokens=max(num_forward_passes, self._family_quirks["min_max_tokens"]),
                 stream=False,
                 seed=self.seed,
                 logprobs=True,
-                top_logprobs=20,
+                top_logprobs=self._family_quirks["top_logprobs_max"],
             )
+
+        # gpt-5.x refuses `logprobs` requests unless reasoning_effort='none'
+        # is set — pass it only for MCQ/numeric (CoT reads free-form text and
+        # benefits from the model's default reasoning budget).
+        if (
+            not isinstance(question, ChainOfThoughtQA)
+            and self._family_quirks["force_reasoning_none"]
+        ):
+            api_call_params["reasoning_effort"] = "none"
 
         api_call_params = self._filter_supported_params(api_call_params)
 

--- a/folktexts/llm_utils.py
+++ b/folktexts/llm_utils.py
@@ -366,7 +366,7 @@ def decode_topk_logprobs_to_risk_estimate(
 
     Notes
     -----
-    Both the WebAPI backend (top_logprobs=20 from OpenAI-style responses) and
+    Both the WebAPI backend (top_logprobs clamped per model family, up to 20) and
     the vLLM backend (top-K logprobs from `SamplingParams(logprobs=K)`) call
     this helper. The transformers backend reads the full softmax directly and
     bypasses this path; see `query_model_batch_multiple_passes`.

--- a/folktexts/qa_interface.py
+++ b/folktexts/qa_interface.py
@@ -341,13 +341,11 @@ class DirectNumericQA(QAInterface):
         # Restrict to tokens that could be an integer percentage answer.
         # Rejects: multi-digit tokens with a `.`, values >100, non-digit
         # strings that slipped through _get_numeric_tokens.
-        valid_percent_tokens: dict[str, int] = {}
-        for tok, tid in numeric_tokens_vocab.items():
-            if not re.fullmatch(r"\d{1,3}", tok):
-                continue
-            value = int(tok)
-            if 0 <= value <= 100:
-                valid_percent_tokens[tok] = tid
+        valid_percent_tokens: dict[str, int] = {
+            tok: tid
+            for tok, tid in numeric_tokens_vocab.items()
+            if re.fullmatch(r"\d{1,3}", tok) and 0 <= int(tok) <= 100
+        }
         if not valid_percent_tokens:
             logging.warning(
                 "No valid percentage tokens (integers 0-100) in the model's "
@@ -379,9 +377,7 @@ class DirectNumericQA(QAInterface):
 
             probs_by_value: dict[int, float] = {}
             for tok, tid in valid_percent_tokens.items():
-                p = ltp[tid]
-                if not isinstance(p, float):
-                    p = p.item()
+                p = float(ltp[tid])
                 if p > 0:
                     probs_by_value[int(tok)] = probs_by_value.get(int(tok), 0.0) + p
             total_mass = sum(probs_by_value.values())
@@ -394,9 +390,8 @@ class DirectNumericQA(QAInterface):
             return min(expected / 100.0, 1.0)
 
         logging.warning(
-            "No post-anchor digit position found in percentage-mode "
-            "response (accumulated_text=%r); returning 0.0.",
-            accumulated_text,
+            f"No post-anchor digit position found in percentage-mode "
+            f"response (accumulated_text={accumulated_text!r}); returning 0.0."
         )
         return 0.0
 

--- a/folktexts/qa_interface.py
+++ b/folktexts/qa_interface.py
@@ -263,7 +263,7 @@ class DirectNumericQA(QAInterface):
         # violates.
         if self.percentage:
             return self._decode_percentage_expected_value(
-                last_token_probs, numeric_tokens_vocab
+                last_token_probs, numeric_tokens_vocab, tokenizer_vocab
             )
 
         answer_text = ""
@@ -294,19 +294,49 @@ class DirectNumericQA(QAInterface):
         else:
             return float(numeric_answer_text)
 
+    # Preamble anchor for percentage-mode decoding. Matches the `probability`
+    # keyword (case-insensitive) followed by a colon at any distance, which
+    # is where all gpt-5-style responses (and the underlying prompt
+    # `NUMERIC_PERCENTAGE_CHAT_PROMPT`) place their answer delimiter:
+    #   - `**Probability (0-100): 28%**`      -> `Probability (0-100):`
+    #   - `**Estimated probability: 18%**`    -> `probability:`
+    #   - `**Probability (above $50,000): ~62%**` -> `Probability (above $50,000):`
+    # `[^:]*` deliberately stops at the FIRST colon after `probability`,
+    # so any digit tokens the model emits as prompt echo (the `0` and `100`
+    # in `(0-100)`) precede the anchor and are correctly skipped.
+    _ANSWER_ANCHOR: ClassVar[re.Pattern] = re.compile(
+        r"probability[^:]*:", re.IGNORECASE
+    )
+
     def _decode_percentage_expected_value(
         self,
         last_token_probs: np.ndarray,
         numeric_tokens_vocab: dict[str, int],
+        tokenizer_vocab: dict[str, int],
     ) -> float:
-        """Decode a percentage-mode response.
+        """Decode a percentage-mode response deterministically.
 
-        Real API responses often prefix the digit with markdown echo (e.g.
-        `'**Probability (0-100): 28**'`), so we scan every position for the
-        one where numeric-token mass concentrates on plausible percentage
-        values (integers in [0, 100]) and compute a mass-weighted expected
-        value at that position. Falls back to 0.0 if no such position
-        exists (model emitted no digits at all).
+        Real gpt-5 responses either echo the prompt's `(0-100)` range
+        label (`'**Probability (0-100): 28%**'`) or paraphrase it
+        (`'**Estimated probability: 18%**'`) before the answer digit.
+        Argmax-per-position over the whole response is noisy: the `0`
+        and `100` from the range label carry high probability and can
+        hijack the "best answer position" selection.
+
+        Algorithm:
+          1. Reconstruct the chosen-token stream via argmax per
+             position (temperature=0 guarantees chosen == argmax).
+          2. Walk positions accumulating text; once the accumulated
+             text matches `_ANSWER_ANCHOR` (`probability<...>:`), mark
+             the anchor as consumed.
+          3. Return the mass-weighted expected value of integer-percent
+             tokens at the first *post-anchor* position that carries
+             meaningful numeric mass.
+
+        Falls back to 0.0 when either no anchor appears (the model
+        never framed the answer as a probability — usually a preamble
+        that never reached the digit) or no post-anchor position
+        carries digit mass.
         """
         # Restrict to tokens that could be an integer percentage answer.
         # Rejects: multi-digit tokens with a `.`, values >100, non-digit
@@ -325,10 +355,28 @@ class DirectNumericQA(QAInterface):
             )
             return 0.0
 
-        best_pos_idx = -1
-        best_pos_mass = -1.0
-        best_pos_expected = 0.0
+        # Reconstruct chosen tokens per position to walk the response text
+        # deterministically. `tokenizer_vocab` on the WebAPI backend is a
+        # synthetic map (token string → sequential id) built from the top-K
+        # entries actually returned for this row, so the inverse is total
+        # on the ids that appear as argmax.
+        inverse_vocab = {tid: tok for tok, tid in tokenizer_vocab.items()}
+
+        passed_anchor = False
+        accumulated_text = ""
         for pos_idx, ltp in enumerate(last_token_probs):
+            chosen_id = int(np.argmax(ltp))
+            chosen_tok = inverse_vocab.get(chosen_id, "")
+            accumulated_text += chosen_tok
+
+            if not passed_anchor:
+                if self._ANSWER_ANCHOR.search(accumulated_text):
+                    passed_anchor = True
+                # Everything before/at the anchor is prompt echo (label
+                # digits like `0`/`100`, punctuation, preamble words) —
+                # never the answer, even when it's a valid percentage.
+                continue
+
             probs_by_value: dict[int, float] = {}
             for tok, tid in valid_percent_tokens.items():
                 p = ltp[tid]
@@ -337,32 +385,20 @@ class DirectNumericQA(QAInterface):
                 if p > 0:
                     probs_by_value[int(tok)] = probs_by_value.get(int(tok), 0.0) + p
             total_mass = sum(probs_by_value.values())
-            if total_mass <= 0:
+            # Positions between the label and the answer (whitespace,
+            # `):`, `%`, etc.) carry no numeric mass; skip them.
+            if total_mass < 0.1:
                 continue
-            # Skip positions where a single value dominates (>95% of mass)
-            # — those are almost always range-label positions like the `0`
-            # or `100` in `(0-100)`, not the answer. Real answer positions
-            # have a spread of plausible percentages (probe on gpt-5.4-nano:
-            # top value ≈0.3-0.5 with 4-5 alternatives sharing the rest).
-            max_single_value_prob = max(probs_by_value.values())
-            if max_single_value_prob > 0.95 * total_mass:
-                continue
-            if total_mass > best_pos_mass:
-                best_pos_mass = total_mass
-                best_pos_idx = pos_idx
-                # Mass-weighted expected value over the numeric tokens.
-                best_pos_expected = (
-                    sum(v * p for v, p in probs_by_value.items()) / total_mass
-                )
 
-        if best_pos_idx < 0 or best_pos_mass < 0.1:
-            logging.warning(
-                f"No confident percentage answer found "
-                f"(best_pos_mass={best_pos_mass:.3f}); returning 0.0."
-            )
-            return 0.0
+            expected = sum(v * p for v, p in probs_by_value.items()) / total_mass
+            return min(expected / 100.0, 1.0)
 
-        return min(best_pos_expected / 100.0, 1.0)
+        logging.warning(
+            "No post-anchor digit position found in percentage-mode "
+            "response (accumulated_text=%r); returning 0.0.",
+            accumulated_text,
+        )
+        return 0.0
 
 
 @dataclass(frozen=True, eq=True)

--- a/folktexts/qa_interface.py
+++ b/folktexts/qa_interface.py
@@ -54,6 +54,14 @@ GEMMA_CHAT_PROMPT = "The provided information suggests that the answer is"
 # space and may degrade calibration for low-probability cases).
 NUMERIC_CHAT_PROMPT = "Answer (between 0 and 1): 0."
 
+# Alternative prefill used when `DirectNumericQA(percentage=True)` is active:
+# no `0.` prefill; the model is asked to reply with an integer percentage.
+# Rationale: OpenAI gpt-5 under `reasoning_effort='none'` collapses the
+# decimal-prefill prompt to `'0'` regardless of input (AUC≈chance); reframing
+# as an integer percentage restores discrimination because both digits become
+# meaningful (probe on gpt-5.4-nano: HIGH-income row → '92', LOW → '12').
+NUMERIC_PERCENTAGE_CHAT_PROMPT = "Probability (0-100): "
+
 
 @dataclass(frozen=True)
 class QAInterface(ABC):
@@ -145,11 +153,19 @@ class DirectNumericQA(QAInterface):
 
     num_forward_passes: int = 2  # NOTE: overrides superclass default
     answer_probability: bool = True
+    percentage: bool = False
+    """Ask the model for an integer percentage (0-100) instead of a decimal
+    with a `0.` prefill; the decoded value is divided by 100. Used to work
+    around OpenAI gpt-5 models degenerating to `'0'` under the decimal-prefill
+    prompt when `reasoning_effort='none'` is required for logprobs.
+    Auto-enabled by `WebAPILLMClassifier` for gpt-5 family models."""
 
     default_system_prompt: ClassVar[str] = NUMERIC_SYSTEM_PROMPT
     default_chat_prompt: ClassVar[str] = NUMERIC_CHAT_PROMPT
 
     def get_answer_prefix(self) -> str:
+        if self.percentage:
+            return NUMERIC_PERCENTAGE_CHAT_PROMPT
         if self.answer_probability:
             return "Answer (between 0 and 1): 0."
         return "Answer: "
@@ -240,6 +256,16 @@ class DirectNumericQA(QAInterface):
                 f"{len(last_token_probs)}."
             )
 
+        # Percentage mode uses its own decoder: the model prefixes markdown
+        # around the digit, so a per-position argmax over the entire response
+        # captures noise. Return early — the classic sequential-digit decoder
+        # below assumes a `0.<digit><digit>...` layout that percentage mode
+        # violates.
+        if self.percentage:
+            return self._decode_percentage_expected_value(
+                last_token_probs, numeric_tokens_vocab
+            )
+
         answer_text = ""
         for ltp in last_token_probs:
             # Get the probability of each numeric token
@@ -267,6 +293,76 @@ class DirectNumericQA(QAInterface):
             return float(f"0.{numeric_answer_text}")
         else:
             return float(numeric_answer_text)
+
+    def _decode_percentage_expected_value(
+        self,
+        last_token_probs: np.ndarray,
+        numeric_tokens_vocab: dict[str, int],
+    ) -> float:
+        """Decode a percentage-mode response.
+
+        Real API responses often prefix the digit with markdown echo (e.g.
+        `'**Probability (0-100): 28**'`), so we scan every position for the
+        one where numeric-token mass concentrates on plausible percentage
+        values (integers in [0, 100]) and compute a mass-weighted expected
+        value at that position. Falls back to 0.0 if no such position
+        exists (model emitted no digits at all).
+        """
+        # Restrict to tokens that could be an integer percentage answer.
+        # Rejects: multi-digit tokens with a `.`, values >100, non-digit
+        # strings that slipped through _get_numeric_tokens.
+        valid_percent_tokens: dict[str, int] = {}
+        for tok, tid in numeric_tokens_vocab.items():
+            if not re.fullmatch(r"\d{1,3}", tok):
+                continue
+            value = int(tok)
+            if 0 <= value <= 100:
+                valid_percent_tokens[tok] = tid
+        if not valid_percent_tokens:
+            logging.warning(
+                "No valid percentage tokens (integers 0-100) in the model's "
+                "response; returning 0.0."
+            )
+            return 0.0
+
+        best_pos_idx = -1
+        best_pos_mass = -1.0
+        best_pos_expected = 0.0
+        for pos_idx, ltp in enumerate(last_token_probs):
+            probs_by_value: dict[int, float] = {}
+            for tok, tid in valid_percent_tokens.items():
+                p = ltp[tid]
+                if not isinstance(p, float):
+                    p = p.item()
+                if p > 0:
+                    probs_by_value[int(tok)] = probs_by_value.get(int(tok), 0.0) + p
+            total_mass = sum(probs_by_value.values())
+            if total_mass <= 0:
+                continue
+            # Skip positions where a single value dominates (>95% of mass)
+            # — those are almost always range-label positions like the `0`
+            # or `100` in `(0-100)`, not the answer. Real answer positions
+            # have a spread of plausible percentages (probe on gpt-5.4-nano:
+            # top value ≈0.3-0.5 with 4-5 alternatives sharing the rest).
+            max_single_value_prob = max(probs_by_value.values())
+            if max_single_value_prob > 0.95 * total_mass:
+                continue
+            if total_mass > best_pos_mass:
+                best_pos_mass = total_mass
+                best_pos_idx = pos_idx
+                # Mass-weighted expected value over the numeric tokens.
+                best_pos_expected = (
+                    sum(v * p for v, p in probs_by_value.items()) / total_mass
+                )
+
+        if best_pos_idx < 0 or best_pos_mass < 0.1:
+            logging.warning(
+                f"No confident percentage answer found "
+                f"(best_pos_mass={best_pos_mass:.3f}); returning 0.0."
+            )
+            return 0.0
+
+        return min(best_pos_expected / 100.0, 1.0)
 
 
 @dataclass(frozen=True, eq=True)

--- a/folktexts/qa_interface.py
+++ b/folktexts/qa_interface.py
@@ -364,7 +364,7 @@ class DirectNumericQA(QAInterface):
 
         passed_anchor = False
         accumulated_text = ""
-        for pos_idx, ltp in enumerate(last_token_probs):
+        for ltp in last_token_probs:
             chosen_id = int(np.argmax(ltp))
             chosen_tok = inverse_vocab.get(chosen_id, "")
             accumulated_text += chosen_tok

--- a/tests/test_web_api_classifier.py
+++ b/tests/test_web_api_classifier.py
@@ -421,41 +421,104 @@ def test_directnumericqa_percentage_prefix_has_no_decimal_prefill():
 
 def test_directnumericqa_percentage_decode_expected_value():
     """`percentage=True` returns a mass-weighted expected value over the
-    numeric tokens at the highest-confidence position, divided by 100."""
+    numeric tokens at the first post-`probability<...>:` position with
+    meaningful numeric mass, divided by 100."""
     import numpy as np
     from folktexts.qa_interface import DirectNumericQA
     q = DirectNumericQA(
-        column="test", text="P?", num_forward_passes=1, percentage=True,
+        column="test", text="P?", num_forward_passes=4, percentage=True,
     )
-    # Position 0: only '92' has meaningful mass → expected value = 92.
-    vocab = {"92": 0, "88": 1, "12": 2}
-    probs = np.zeros((1, 3))
-    probs[0, 0] = 0.9   # '92'
-    probs[0, 1] = 0.05  # '88' → expected = (92*0.9 + 88*0.05 + 12*0.05) / 1.0 = 87.8
-    probs[0, 2] = 0.05  # '12'
+    # Simulate `'**Probability (0-100): 92%**'`-style response: the
+    # accumulated text hits `probability(0-100):` by pos 2, then the
+    # answer arrives at pos 3.
+    vocab = {
+        "92": 0, "88": 1, "12": 2,           # answer tokens
+        "**Probability ": 3, "(0-100):": 4, " ": 5,
+    }
+    probs = np.zeros((4, 6))
+    probs[0, 3] = 1.0   # '**Probability '
+    probs[1, 4] = 1.0   # '(0-100):'    (anchor `Probability (0-100):` fires)
+    probs[2, 5] = 1.0   # ' '           (whitespace, no numeric mass → skip)
+    probs[3, 0] = 0.9   # '92'   → expected = (92*0.9 + 88*0.05 + 12*0.05) / 1.0 = 87.8
+    probs[3, 1] = 0.05  # '88'
+    probs[3, 2] = 0.05  # '12'
     decoded = q.get_answer_from_model_output(probs, vocab)
     assert decoded == pytest.approx(0.878)
 
 
-def test_directnumericqa_percentage_finds_answer_across_positions():
-    """When the model wraps the digit in markdown (early positions have no
-    digit mass, digit appears at a later position), the decoder should
-    lock onto the answer position rather than concatenate noise."""
+def test_directnumericqa_percentage_skips_range_label_digits():
+    """The `0` and `100` from an echoed `(0-100)` range label are valid
+    percentages, but appear BEFORE the anchor colon and must be skipped.
+    The decoder should walk to the first post-anchor position that
+    carries digit mass."""
+    import numpy as np
+    from folktexts.qa_interface import DirectNumericQA
+    q = DirectNumericQA(
+        column="test", text="P?", num_forward_passes=6, percentage=True,
+    )
+    # Response shape: '**Probability 0 - 100 ): 35'
+    # Prefix tokens produce accumulated `**Probability 0-100):` by
+    # position 5, so the anchor `probability[^:]*:` matches. Answer at
+    # position 5 must NOT be the `100` (still pre-anchor) — verify by
+    # placing the real answer at position 6.
+    vocab = {
+        "35": 0, "100": 1, "0": 2, "-": 3, "):": 4,
+        "**Probability ": 5,
+    }
+    probs = np.zeros((7, 6))
+    probs[0, 5] = 1.0    # '**Probability '  (no anchor yet — no colon)
+    probs[1, 2] = 1.0    # '0'               (range label starts)
+    probs[2, 3] = 1.0    # '-'
+    probs[3, 1] = 1.0    # '100'             (still pre-anchor — no colon yet)
+    probs[4, 4] = 1.0    # '):'              (accumulated hits `Probability 0-100):`)
+    probs[5, 0] = 0.0    # (empty — skipped, no mass)
+    probs[6, 0] = 0.6    # '35'              (post-anchor answer)
+    probs[6, 2] = 0.3    # '0'               (contributes 0)
+    decoded = q.get_answer_from_model_output(probs, vocab)
+    # Expected = (35*0.6 + 0*0.3 + 100*0) / 0.9 = 21 / 0.9 = 23.333...
+    # `100` doesn't appear at pos 6 → not counted.
+    assert decoded == pytest.approx(23.333 / 100.0, abs=0.001)
+
+
+def test_directnumericqa_percentage_returns_zero_without_anchor():
+    """When the model preambles for the entire token budget without
+    ever emitting `probability<...>:`, the decoder should return 0.0 —
+    those responses (~4% on gpt-5.4-nano) contain no answer to decode,
+    and inventing one would harm calibration."""
     import numpy as np
     from folktexts.qa_interface import DirectNumericQA
     q = DirectNumericQA(
         column="test", text="P?", num_forward_passes=3, percentage=True,
     )
-    # 3 positions × 3 numeric tokens. Position 0: no numeric mass.
-    # Position 1: dominated by literal `100` (the range label — should be
-    # rejected). Position 2: real answer at 35 with some spread.
-    vocab = {"35": 0, "100": 1, "0": 2}
+    # Preamble that never reaches the anchor `probability:`, but
+    # includes a numeric-looking token (`42` from `**42-year-old`).
+    vocab = {"42": 0, "Doctorate": 1, "**": 2}
     probs = np.zeros((3, 3))
-    probs[0, :] = [0.0, 0.0, 0.0]        # pos 0: no digits (e.g. '**')
-    probs[1, :] = [0.0, 0.99, 0.0]       # pos 1: only '100' — must be skipped
-    probs[2, :] = [0.6, 0.0, 0.3]        # pos 2: '35' dominates; expected = 35*0.6/0.9 = 23.33...
+    probs[0, 2] = 1.0   # '**'
+    probs[1, 0] = 1.0   # '42' — a numeric token but before any anchor
+    probs[2, 1] = 1.0   # 'Doctorate'
     decoded = q.get_answer_from_model_output(probs, vocab)
-    assert decoded == pytest.approx(23.333 / 100.0, abs=0.001)
+    assert decoded == 0.0
+
+
+def test_directnumericqa_percentage_accepts_paraphrased_anchor():
+    """Real gpt-5 responses often drop the `(0-100)` range label and
+    paraphrase (e.g. `'**Estimated probability: 18%**'`). The anchor
+    matches `probability<anything>:` so paraphrases still decode."""
+    import numpy as np
+    from folktexts.qa_interface import DirectNumericQA
+    q = DirectNumericQA(
+        column="test", text="P?", num_forward_passes=4, percentage=True,
+    )
+    # Response: '**Estimated probability: 18%**'
+    vocab = {"18": 0, "**Estimated probability": 1, ":": 2, " ": 3}
+    probs = np.zeros((4, 4))
+    probs[0, 1] = 1.0   # '**Estimated probability'  (no anchor yet)
+    probs[1, 2] = 1.0   # ':'                        (anchor fires here)
+    probs[2, 3] = 1.0   # ' '                        (whitespace — skip)
+    probs[3, 0] = 1.0   # '18'                       (answer)
+    decoded = q.get_answer_from_model_output(probs, vocab)
+    assert decoded == pytest.approx(0.18)
 
 
 def test_directnumericqa_percentage_clamps_above_100():

--- a/tests/test_web_api_classifier.py
+++ b/tests/test_web_api_classifier.py
@@ -589,6 +589,73 @@ def test_enable_numeric_percentage_mode_swaps_question(mcq_task):
     assert clf._active_question is new_q
 
 
+def test_enable_numeric_percentage_mode_installs_format_system_prompt(mcq_task):
+    """The swap should replace the default numeric system prompt with one
+    that explicitly names the required answer format (mirrors the CoT
+    pattern) — reasoning models don't reliably continue the user-turn
+    prefill, so the instruction reduces zero-fallback rows."""
+    from folktexts.classifier.web_api_classifier import (
+        NUMERIC_PERCENTAGE_SYSTEM_PROMPT,
+    )
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
+    )
+    clf, _ = _make_classifier(cfg)
+    clf._task = mcq_task
+
+    # Precondition: numeric-QA default system prompt is active
+    assert clf._prompt_config.system_prompt is not None
+    assert "MUST end" not in clf._prompt_config.system_prompt()
+
+    clf._enable_numeric_percentage_mode()
+
+    new_sys = clf._prompt_config.system_prompt()
+    assert new_sys == NUMERIC_PERCENTAGE_SYSTEM_PROMPT
+    assert "Probability (0-100): X%" in new_sys
+    # Instruction shape: forbid preamble/reasoning so the model emits the
+    # answer inside the (limited) `max_tokens` budget.
+    assert "Reply with ONLY" in new_sys
+    assert "no preamble".lower() in new_sys.lower() or \
+        "no preamble, reasoning".lower() in new_sys.lower() or \
+        "preamble" in new_sys
+
+
+def test_enable_numeric_percentage_mode_preserves_user_system_prompt(mcq_task):
+    """A user-supplied `--system-prompt` must NOT be silently clobbered by
+    the auto-swap (only the QA subclass default gets replaced)."""
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
+        system_prompt="CUSTOM USER SYS",
+    )
+    clf, _ = _make_classifier(cfg)
+    clf._task = mcq_task
+
+    assert clf._prompt_config.system_prompt() == "CUSTOM USER SYS"
+
+    clf._enable_numeric_percentage_mode()
+
+    # QA is still swapped …
+    assert clf._prompt_config.suffix.question.percentage is True
+    # … but the user's system prompt is preserved
+    assert clf._prompt_config.system_prompt() == "CUSTOM USER SYS"
+
+
+def test_enable_numeric_percentage_mode_preserves_disabled_system_prompt(mcq_task):
+    """`system_prompt=None` (role disabled) must stay disabled after swap."""
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
+        system_prompt=None,
+    )
+    clf, _ = _make_classifier(cfg)
+    clf._task = mcq_task
+    assert clf._prompt_config.system_prompt is None
+
+    clf._enable_numeric_percentage_mode()
+
+    assert clf._prompt_config.suffix.question.percentage is True
+    assert clf._prompt_config.system_prompt is None
+
+
 def test_gpt5_init_auto_enables_percentage_mode_for_numeric_qa(monkeypatch, mcq_task):
     """End-to-end: constructing a WebAPILLMClassifier for a gpt-5 model with
     a numeric-QA task should auto-swap the numeric QA to percentage mode."""
@@ -622,6 +689,8 @@ def test_gpt5_init_auto_enables_percentage_mode_for_numeric_qa(monkeypatch, mcq_
     assert isinstance(q, DirectNumericQA)
     assert q.percentage is True
     assert q.num_forward_passes >= 10
+    # And the format-instruction system prompt is installed
+    assert "Probability (0-100): X%" in clf._prompt_config.system_prompt()
 
 
 def test_default_model_init_does_not_swap_numeric_qa(monkeypatch, mcq_task):
@@ -653,6 +722,10 @@ def test_default_model_init_does_not_swap_numeric_qa(monkeypatch, mcq_task):
     q = clf._prompt_config.suffix.question
     assert isinstance(q, DirectNumericQA)
     assert q.percentage is False
+    # Non-gpt-5 path keeps the plain numeric system prompt (no format
+    # instruction — regular models honour the user-turn prefill continuation).
+    assert "Reply with ONLY" not in clf._prompt_config.system_prompt()
+    assert "Probability (0-100)" not in clf._prompt_config.system_prompt()
 
 
 def test_gpt5_init_does_not_swap_mcq(monkeypatch, mcq_task):

--- a/tests/test_web_api_classifier.py
+++ b/tests/test_web_api_classifier.py
@@ -16,7 +16,10 @@ from __future__ import annotations
 import pytest
 
 from folktexts.classifier import WebAPILLMClassifier
-from folktexts.classifier.web_api_classifier import _DEFAULT_FAMILY_QUIRKS
+from folktexts.classifier.web_api_classifier import (
+    _DEFAULT_FAMILY_QUIRKS,
+    _WebAPIQuirks,
+)
 from folktexts.prompting import PromptConfig
 from folktexts.qa_interface import ChainOfThoughtQA
 
@@ -272,18 +275,13 @@ def test_missing_logprobs_support_fails_fast_for_mcq(mcq_task):
 
 # --- gpt-5 family quirks -----------------------------------------------------
 
-_GPT5_QUIRKS = {
-    "top_logprobs_max": 5,
-    "max_tokens_overhead": 3,
-    "force_reasoning_none": True,
-    "numeric_percentage_mode": True,
-}
-_DEFAULT_QUIRKS = {
-    "top_logprobs_max": 20,
-    "max_tokens_overhead": 0,
-    "force_reasoning_none": False,
-    "numeric_percentage_mode": False,
-}
+_GPT5_QUIRKS = _WebAPIQuirks(
+    top_logprobs_max=5,
+    max_tokens_overhead=3,
+    force_reasoning_none=True,
+    numeric_percentage_mode=True,
+)
+_DEFAULT_QUIRKS = _WebAPIQuirks()
 
 
 @pytest.mark.parametrize("model_name, expected", [
@@ -769,7 +767,7 @@ def test_gpt5_init_auto_enables_percentage_mode_for_numeric_qa(monkeypatch, mcq_
     def _fake_completion(**_kwargs):
         raise RuntimeError("should not be called in __init__")
 
-    import litellm as real_litellm
+    real_litellm = pytest.importorskip("litellm")
     monkeypatch.setattr(real_litellm, "success_callback", [], raising=False)
     monkeypatch.setattr(real_litellm, "completion", _fake_completion, raising=False)
     monkeypatch.setattr(
@@ -803,7 +801,7 @@ def test_default_model_init_does_not_swap_numeric_qa(monkeypatch, mcq_task):
     def _fake_completion(**_kwargs):
         raise RuntimeError("should not be called in __init__")
 
-    import litellm as real_litellm
+    real_litellm = pytest.importorskip("litellm")
     monkeypatch.setattr(real_litellm, "success_callback", [], raising=False)
     monkeypatch.setattr(real_litellm, "completion", _fake_completion, raising=False)
     monkeypatch.setattr(
@@ -838,7 +836,7 @@ def test_gpt5_init_does_not_swap_mcq(monkeypatch, mcq_task):
     def _fake_completion(**_kwargs):
         raise RuntimeError("should not be called in __init__")
 
-    import litellm as real_litellm
+    real_litellm = pytest.importorskip("litellm")
     monkeypatch.setattr(real_litellm, "success_callback", [], raising=False)
     monkeypatch.setattr(real_litellm, "completion", _fake_completion, raising=False)
     monkeypatch.setattr(

--- a/tests/test_web_api_classifier.py
+++ b/tests/test_web_api_classifier.py
@@ -42,7 +42,7 @@ def _make_classifier(prompt_config: PromptConfig, *, supported_params: set | Non
     clf._warned_unsupported_params = set()
     clf._family_quirks = {  # default quirks (matches _DEFAULT_FAMILY_QUIRKS)
         "top_logprobs_max": 20,
-        "min_max_tokens": 1,
+        "max_tokens_overhead": 0,
         "force_reasoning_none": False,
     }
 
@@ -272,13 +272,17 @@ def test_missing_logprobs_support_fails_fast_for_mcq(mcq_task):
 
 # --- gpt-5 family quirks -----------------------------------------------------
 
+_GPT5_QUIRKS = {"top_logprobs_max": 5, "max_tokens_overhead": 3, "force_reasoning_none": True}
+_DEFAULT_QUIRKS = {"top_logprobs_max": 20, "max_tokens_overhead": 0, "force_reasoning_none": False}
+
+
 @pytest.mark.parametrize("model_name, expected", [
-    ("gpt-5.4-mini", {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}),
-    ("gpt-5.4-nano", {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}),
-    ("openai/gpt-5-turbo", {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}),
-    ("gpt-4o-mini", {"top_logprobs_max": 20, "min_max_tokens": 1, "force_reasoning_none": False}),
-    ("claude-sonnet-5", {"top_logprobs_max": 20, "min_max_tokens": 1, "force_reasoning_none": False}),
-    ("some-future-model", {"top_logprobs_max": 20, "min_max_tokens": 1, "force_reasoning_none": False}),
+    ("gpt-5.4-mini", _GPT5_QUIRKS),
+    ("gpt-5.4-nano", _GPT5_QUIRKS),
+    ("openai/gpt-5-turbo", _GPT5_QUIRKS),
+    ("gpt-4o-mini", _DEFAULT_QUIRKS),
+    ("claude-sonnet-5", _DEFAULT_QUIRKS),
+    ("some-future-model", _DEFAULT_QUIRKS),
 ])
 def test_resolve_family_quirks(model_name, expected):
     from folktexts.classifier.web_api_classifier import _resolve_family_quirks
@@ -289,24 +293,39 @@ def test_mcq_sends_family_specific_top_logprobs_cap(mcq_task):
     """gpt-5 models must receive top_logprobs=5 (any higher → OpenAI 400)."""
     cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
     clf, _ = _make_classifier(cfg)
-    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+    clf._family_quirks = _GPT5_QUIRKS
 
     clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
     assert clf.last_call_params["top_logprobs"] == 5
 
 
-def test_mcq_bumps_max_tokens_for_gpt5_family(mcq_task):
-    """gpt-5 refuses max_tokens<4 for the single-token MCQ path; bump it."""
+def test_mcq_max_tokens_absorbs_overhead_for_gpt5(mcq_task):
+    """gpt-5 has a ~3-token hidden preamble that consumes max_completion_tokens;
+    a single-token MCQ needs `max_tokens = 1 + overhead = 4`."""
     cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
     clf, _ = _make_classifier(cfg)
-    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+    clf._family_quirks = _GPT5_QUIRKS
 
     clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
     assert clf.last_call_params["max_tokens"] == 4
 
 
+def test_numeric_max_tokens_absorbs_overhead_for_gpt5(mcq_task):
+    """Numeric needs `num_forward_passes + 2 + overhead` visible tokens for gpt-5;
+    without the overhead the model outputs only '0.' and decodes to 0.0."""
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
+    )
+    clf, _ = _make_classifier(cfg)
+    clf._family_quirks = _GPT5_QUIRKS
+    expected = mcq_task.direct_numeric_qa.num_forward_passes + 2 + 3
+
+    clf._query_webapi_batch(["p"], question=mcq_task.direct_numeric_qa)
+    assert clf.last_call_params["max_tokens"] == expected
+
+
 def test_mcq_default_max_tokens_unchanged_for_non_gpt5(mcq_task):
-    """Non-gpt-5 models keep max_tokens=1 for single-token MCQ (no bump)."""
+    """Non-gpt-5 models keep max_tokens=1 for single-token MCQ (no overhead)."""
     cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
     clf, _ = _make_classifier(cfg)  # default quirks
     clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
@@ -317,7 +336,7 @@ def test_mcq_injects_reasoning_effort_none_for_gpt5(mcq_task):
     """gpt-5 needs reasoning_effort='none' or logprobs requests are refused."""
     cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
     clf, _ = _make_classifier(cfg)
-    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+    clf._family_quirks = _GPT5_QUIRKS
 
     clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
     assert clf.last_call_params.get("reasoning_effort") == "none"
@@ -328,7 +347,7 @@ def test_numeric_injects_reasoning_effort_none_for_gpt5(mcq_task):
         pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
     )
     clf, _ = _make_classifier(cfg)
-    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+    clf._family_quirks = _GPT5_QUIRKS
 
     clf._query_webapi_batch(["p"], question=mcq_task.direct_numeric_qa)
     assert clf.last_call_params.get("reasoning_effort") == "none"
@@ -340,7 +359,7 @@ def test_cot_does_not_inject_reasoning_effort_even_for_gpt5(mcq_task):
         pv={}, task=mcq_task, question=_cot_question(mcq_task),
     )
     clf, _ = _make_classifier(cfg)
-    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+    clf._family_quirks = _GPT5_QUIRKS
 
     clf._query_webapi_batch(["p"], question=_cot_question(mcq_task))
     assert "reasoning_effort" not in clf.last_call_params

--- a/tests/test_web_api_classifier.py
+++ b/tests/test_web_api_classifier.py
@@ -37,8 +37,14 @@ def _make_classifier(prompt_config: PromptConfig, *, supported_params: set | Non
     clf.max_api_rpm = 10**9  # make the inter-call sleep negligible
     clf.supported_params = supported_params if supported_params is not None else {
         "temperature", "max_tokens", "stream", "seed", "logprobs", "top_logprobs",
+        "reasoning_effort",
     }
     clf._warned_unsupported_params = set()
+    clf._family_quirks = {  # default quirks (matches _DEFAULT_FAMILY_QUIRKS)
+        "top_logprobs_max": 20,
+        "min_max_tokens": 1,
+        "force_reasoning_none": False,
+    }
 
     calls: list[list[dict]] = []
 
@@ -262,6 +268,90 @@ def test_missing_logprobs_support_fails_fast_for_mcq(mcq_task):
     with pytest.raises(RuntimeError, match="logprobs"):
         clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
     assert calls == []  # no API call was made
+
+
+# --- gpt-5 family quirks -----------------------------------------------------
+
+@pytest.mark.parametrize("model_name, expected", [
+    ("gpt-5.4-mini", {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}),
+    ("gpt-5.4-nano", {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}),
+    ("openai/gpt-5-turbo", {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}),
+    ("gpt-4o-mini", {"top_logprobs_max": 20, "min_max_tokens": 1, "force_reasoning_none": False}),
+    ("claude-sonnet-5", {"top_logprobs_max": 20, "min_max_tokens": 1, "force_reasoning_none": False}),
+    ("some-future-model", {"top_logprobs_max": 20, "min_max_tokens": 1, "force_reasoning_none": False}),
+])
+def test_resolve_family_quirks(model_name, expected):
+    from folktexts.classifier.web_api_classifier import _resolve_family_quirks
+    assert _resolve_family_quirks(model_name) == expected
+
+
+def test_mcq_sends_family_specific_top_logprobs_cap(mcq_task):
+    """gpt-5 models must receive top_logprobs=5 (any higher → OpenAI 400)."""
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(cfg)
+    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+
+    clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
+    assert clf.last_call_params["top_logprobs"] == 5
+
+
+def test_mcq_bumps_max_tokens_for_gpt5_family(mcq_task):
+    """gpt-5 refuses max_tokens<4 for the single-token MCQ path; bump it."""
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(cfg)
+    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+
+    clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
+    assert clf.last_call_params["max_tokens"] == 4
+
+
+def test_mcq_default_max_tokens_unchanged_for_non_gpt5(mcq_task):
+    """Non-gpt-5 models keep max_tokens=1 for single-token MCQ (no bump)."""
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(cfg)  # default quirks
+    clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
+    assert clf.last_call_params["max_tokens"] == 1
+
+
+def test_mcq_injects_reasoning_effort_none_for_gpt5(mcq_task):
+    """gpt-5 needs reasoning_effort='none' or logprobs requests are refused."""
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(cfg)
+    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+
+    clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
+    assert clf.last_call_params.get("reasoning_effort") == "none"
+
+
+def test_numeric_injects_reasoning_effort_none_for_gpt5(mcq_task):
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
+    )
+    clf, _ = _make_classifier(cfg)
+    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+
+    clf._query_webapi_batch(["p"], question=mcq_task.direct_numeric_qa)
+    assert clf.last_call_params.get("reasoning_effort") == "none"
+
+
+def test_cot_does_not_inject_reasoning_effort_even_for_gpt5(mcq_task):
+    """CoT reads free-form text — reasoning budget should stay at the model default."""
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=_cot_question(mcq_task),
+    )
+    clf, _ = _make_classifier(cfg)
+    clf._family_quirks = {"top_logprobs_max": 5, "min_max_tokens": 4, "force_reasoning_none": True}
+
+    clf._query_webapi_batch(["p"], question=_cot_question(mcq_task))
+    assert "reasoning_effort" not in clf.last_call_params
+
+
+def test_mcq_omits_reasoning_effort_for_non_gpt5(mcq_task):
+    """Non-gpt-5 models must not receive reasoning_effort (gpt-4o-mini rejects it)."""
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(cfg)  # default quirks
+    clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
+    assert "reasoning_effort" not in clf.last_call_params
 
 
 def test_unsupported_param_warning_fires_once_across_batches(mcq_task, caplog):

--- a/tests/test_web_api_classifier.py
+++ b/tests/test_web_api_classifier.py
@@ -44,7 +44,9 @@ def _make_classifier(prompt_config: PromptConfig, *, supported_params: set | Non
         "top_logprobs_max": 20,
         "max_tokens_overhead": 0,
         "force_reasoning_none": False,
+        "numeric_percentage_mode": False,
     }
+    clf._active_question = None  # no override; falls back to task.question
 
     calls: list[list[dict]] = []
 
@@ -272,8 +274,18 @@ def test_missing_logprobs_support_fails_fast_for_mcq(mcq_task):
 
 # --- gpt-5 family quirks -----------------------------------------------------
 
-_GPT5_QUIRKS = {"top_logprobs_max": 5, "max_tokens_overhead": 3, "force_reasoning_none": True}
-_DEFAULT_QUIRKS = {"top_logprobs_max": 20, "max_tokens_overhead": 0, "force_reasoning_none": False}
+_GPT5_QUIRKS = {
+    "top_logprobs_max": 5,
+    "max_tokens_overhead": 3,
+    "force_reasoning_none": True,
+    "numeric_percentage_mode": True,
+}
+_DEFAULT_QUIRKS = {
+    "top_logprobs_max": 20,
+    "max_tokens_overhead": 0,
+    "force_reasoning_none": False,
+    "numeric_percentage_mode": False,
+}
 
 
 @pytest.mark.parametrize("model_name, expected", [
@@ -390,3 +402,221 @@ def test_unsupported_param_warning_fires_once_across_batches(mcq_task, caplog):
         if "does not support API parameter" in rec.getMessage()
     ]
     assert len(warnings) == 1
+
+
+# --- Numeric percentage mode (gpt-5 workaround) -----------------------------
+
+def test_directnumericqa_percentage_prefix_has_no_decimal_prefill():
+    """With `percentage=True`, the prompt asks for an integer percentage
+    and does NOT bake the `0.` prefill into the user turn."""
+    from folktexts.qa_interface import DirectNumericQA, NUMERIC_PERCENTAGE_CHAT_PROMPT
+    q = DirectNumericQA(
+        column="test", text="What is P?", num_forward_passes=1, percentage=True,
+    )
+    prefix = q.get_answer_prefix()
+    assert prefix == NUMERIC_PERCENTAGE_CHAT_PROMPT
+    assert "0." not in prefix
+    assert "0-100" in prefix
+
+
+def test_directnumericqa_percentage_decode_expected_value():
+    """`percentage=True` returns a mass-weighted expected value over the
+    numeric tokens at the highest-confidence position, divided by 100."""
+    import numpy as np
+    from folktexts.qa_interface import DirectNumericQA
+    q = DirectNumericQA(
+        column="test", text="P?", num_forward_passes=1, percentage=True,
+    )
+    # Position 0: only '92' has meaningful mass → expected value = 92.
+    vocab = {"92": 0, "88": 1, "12": 2}
+    probs = np.zeros((1, 3))
+    probs[0, 0] = 0.9   # '92'
+    probs[0, 1] = 0.05  # '88' → expected = (92*0.9 + 88*0.05 + 12*0.05) / 1.0 = 87.8
+    probs[0, 2] = 0.05  # '12'
+    decoded = q.get_answer_from_model_output(probs, vocab)
+    assert decoded == pytest.approx(0.878)
+
+
+def test_directnumericqa_percentage_finds_answer_across_positions():
+    """When the model wraps the digit in markdown (early positions have no
+    digit mass, digit appears at a later position), the decoder should
+    lock onto the answer position rather than concatenate noise."""
+    import numpy as np
+    from folktexts.qa_interface import DirectNumericQA
+    q = DirectNumericQA(
+        column="test", text="P?", num_forward_passes=3, percentage=True,
+    )
+    # 3 positions × 3 numeric tokens. Position 0: no numeric mass.
+    # Position 1: dominated by literal `100` (the range label — should be
+    # rejected). Position 2: real answer at 35 with some spread.
+    vocab = {"35": 0, "100": 1, "0": 2}
+    probs = np.zeros((3, 3))
+    probs[0, :] = [0.0, 0.0, 0.0]        # pos 0: no digits (e.g. '**')
+    probs[1, :] = [0.0, 0.99, 0.0]       # pos 1: only '100' — must be skipped
+    probs[2, :] = [0.6, 0.0, 0.3]        # pos 2: '35' dominates; expected = 35*0.6/0.9 = 23.33...
+    decoded = q.get_answer_from_model_output(probs, vocab)
+    assert decoded == pytest.approx(23.333 / 100.0, abs=0.001)
+
+
+def test_directnumericqa_percentage_clamps_above_100():
+    """Expected value >100 should clamp to 1.0."""
+    import numpy as np
+    from folktexts.qa_interface import DirectNumericQA
+    q = DirectNumericQA(
+        column="test", text="P?", num_forward_passes=1, percentage=True,
+    )
+    # Only 105 in the vocab. `_get_numeric_tokens` allows any digit token,
+    # but percentage decoder further filters to <=100 — so 105 is REJECTED.
+    # With no valid tokens, decoder returns 0.0 (with warning).
+    vocab = {"105": 0}
+    probs = np.array([[1.0]])
+    decoded = q.get_answer_from_model_output(probs, vocab)
+    assert decoded == 0.0
+
+
+def test_directnumericqa_percentage_no_digits_returns_zero():
+    """If no valid percentage tokens appear at any position, the decoder
+    returns 0.0 rather than raising."""
+    import numpy as np
+    from folktexts.qa_interface import DirectNumericQA
+    q = DirectNumericQA(
+        column="test", text="P?", num_forward_passes=1, percentage=True,
+    )
+    # `_get_numeric_tokens` yields an empty numeric_tokens_vocab if the
+    # response has no digits, so pass a vocab with only a non-digit token.
+    vocab = {"foo": 0}  # `_get_numeric_tokens` would filter this out anyway
+    probs = np.array([[1.0]])
+    decoded = q.get_answer_from_model_output(probs, vocab)
+    assert decoded == 0.0
+
+
+def test_directnumericqa_percentage_false_preserves_decimal_prefill():
+    """Default `percentage=False` still returns the classic `0.` prefill."""
+    from folktexts.qa_interface import DirectNumericQA
+    q = DirectNumericQA(column="test", text="P?")
+    assert q.percentage is False
+    assert q.get_answer_prefix() == "Answer (between 0 and 1): 0."
+
+
+def test_enable_numeric_percentage_mode_swaps_question(mcq_task):
+    """Calling `_enable_numeric_percentage_mode()` should replace the
+    numeric QA in `prompt_config.suffix` with a `percentage=True` variant
+    and rebuild `_encode_row` against the new config."""
+    from folktexts.qa_interface import DirectNumericQA
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
+    )
+    clf, _ = _make_classifier(cfg)
+    clf._task = mcq_task  # required by the encode_row rebuild
+
+    original_q = clf._prompt_config.suffix.question
+    assert isinstance(original_q, DirectNumericQA)
+    assert original_q.percentage is False
+
+    clf._enable_numeric_percentage_mode()
+
+    new_q = clf._prompt_config.suffix.question
+    assert isinstance(new_q, DirectNumericQA)
+    assert new_q.percentage is True
+    # ≥10 to give gpt-5 room for the markdown echo it emits before the digit
+    assert new_q.num_forward_passes >= 10
+    # `_encode_row` should now be a partial closed over the NEW config
+    assert clf._encode_row.keywords["prompt_config"] is clf._prompt_config
+    # `_active_question` is the override the base classifier consults
+    assert clf._active_question is new_q
+
+
+def test_gpt5_init_auto_enables_percentage_mode_for_numeric_qa(monkeypatch, mcq_task):
+    """End-to-end: constructing a WebAPILLMClassifier for a gpt-5 model with
+    a numeric-QA task should auto-swap the numeric QA to percentage mode."""
+    from folktexts.qa_interface import DirectNumericQA
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    fake_litellm = type("_fake_litellm", (), {"success_callback": []})()
+
+    def _fake_get_supported(**_kwargs):
+        return ["temperature", "max_tokens", "stream", "seed",
+                "logprobs", "top_logprobs", "reasoning_effort"]
+
+    def _fake_completion(**_kwargs):
+        raise RuntimeError("should not be called in __init__")
+
+    import litellm as real_litellm
+    monkeypatch.setattr(real_litellm, "success_callback", [], raising=False)
+    monkeypatch.setattr(real_litellm, "completion", _fake_completion, raising=False)
+    monkeypatch.setattr(
+        real_litellm, "get_supported_openai_params", _fake_get_supported,
+        raising=False,
+    )
+
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
+    )
+    clf = WebAPILLMClassifier(
+        model_name="gpt-5.4-nano", task=mcq_task, prompt_config=cfg,
+    )
+    q = clf._prompt_config.suffix.question
+    assert isinstance(q, DirectNumericQA)
+    assert q.percentage is True
+    assert q.num_forward_passes >= 10
+
+
+def test_default_model_init_does_not_swap_numeric_qa(monkeypatch, mcq_task):
+    """A non-gpt-5 model must leave the numeric QA in decimal-prefill mode."""
+    from folktexts.qa_interface import DirectNumericQA
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def _fake_get_supported(**_kwargs):
+        return ["temperature", "max_tokens", "stream", "seed", "logprobs", "top_logprobs"]
+
+    def _fake_completion(**_kwargs):
+        raise RuntimeError("should not be called in __init__")
+
+    import litellm as real_litellm
+    monkeypatch.setattr(real_litellm, "success_callback", [], raising=False)
+    monkeypatch.setattr(real_litellm, "completion", _fake_completion, raising=False)
+    monkeypatch.setattr(
+        real_litellm, "get_supported_openai_params", _fake_get_supported,
+        raising=False,
+    )
+
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=mcq_task.direct_numeric_qa,
+    )
+    clf = WebAPILLMClassifier(
+        model_name="gpt-4o-mini", task=mcq_task, prompt_config=cfg,
+    )
+    q = clf._prompt_config.suffix.question
+    assert isinstance(q, DirectNumericQA)
+    assert q.percentage is False
+
+
+def test_gpt5_init_does_not_swap_mcq(monkeypatch, mcq_task):
+    """The auto-swap must only fire when the current question is a
+    `DirectNumericQA` — MCQ tasks are unaffected."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def _fake_get_supported(**_kwargs):
+        return ["temperature", "max_tokens", "stream", "seed",
+                "logprobs", "top_logprobs", "reasoning_effort"]
+
+    def _fake_completion(**_kwargs):
+        raise RuntimeError("should not be called in __init__")
+
+    import litellm as real_litellm
+    monkeypatch.setattr(real_litellm, "success_callback", [], raising=False)
+    monkeypatch.setattr(real_litellm, "completion", _fake_completion, raising=False)
+    monkeypatch.setattr(
+        real_litellm, "get_supported_openai_params", _fake_get_supported,
+        raising=False,
+    )
+
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)  # MCQ, not numeric
+    clf = WebAPILLMClassifier(
+        model_name="gpt-5.4-nano", task=mcq_task, prompt_config=cfg,
+    )
+    # question is a MultipleChoiceQA, no percentage attribute — the swap
+    # should have been skipped without error.
+    from folktexts.qa_interface import MultipleChoiceQA
+    assert isinstance(clf._prompt_config.suffix.question, MultipleChoiceQA)

--- a/tests/test_web_api_classifier.py
+++ b/tests/test_web_api_classifier.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import pytest
 
 from folktexts.classifier import WebAPILLMClassifier
+from folktexts.classifier.web_api_classifier import _DEFAULT_FAMILY_QUIRKS
 from folktexts.prompting import PromptConfig
 from folktexts.qa_interface import ChainOfThoughtQA
 
@@ -40,13 +41,10 @@ def _make_classifier(prompt_config: PromptConfig, *, supported_params: set | Non
         "reasoning_effort",
     }
     clf._warned_unsupported_params = set()
-    clf._family_quirks = {  # default quirks (matches _DEFAULT_FAMILY_QUIRKS)
-        "top_logprobs_max": 20,
-        "max_tokens_overhead": 0,
-        "force_reasoning_none": False,
-        "numeric_percentage_mode": False,
-    }
-    clf._active_question = None  # no override; falls back to task.question
+    clf._warned_unvalidated_reasoning = False
+    # Bind the module-level default so identity checks in prod code
+    # (`self._family_quirks is _DEFAULT_FAMILY_QUIRKS`) work under tests.
+    clf._family_quirks = _DEFAULT_FAMILY_QUIRKS
 
     calls: list[list[dict]] = []
 
@@ -404,6 +402,106 @@ def test_unsupported_param_warning_fires_once_across_batches(mcq_task, caplog):
     assert len(warnings) == 1
 
 
+# --- Unvalidated-reasoning-model warning ------------------------------------
+
+def test_unvalidated_reasoning_warning_fires_for_mcq(mcq_task, caplog):
+    """MCQ on a model that advertises `reasoning_effort` but is NOT in the
+    quirks table must emit a one-time warning — MCQ/Numeric can silently
+    collapse to chance on reasoning models we haven't tuned for."""
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(cfg)  # default quirks, reasoning_effort in supported
+    clf._model_name = "future-reasoning-model-vX"
+
+    with caplog.at_level("WARNING"):
+        clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
+
+    matches = [
+        rec for rec in caplog.records
+        if "reasoning_effort" in rec.getMessage()
+        and "no validated entry" in rec.getMessage()
+    ]
+    assert len(matches) == 1
+    assert clf._model_name in matches[0].getMessage()
+
+
+def test_unvalidated_reasoning_warning_fires_once_across_batches(mcq_task, caplog):
+    """The warning must be capped at one emission per classifier lifetime."""
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(cfg)
+    clf._model_name = "future-reasoning-model-vX"
+
+    with caplog.at_level("WARNING"):
+        clf._query_webapi_batch(["p1"], question=mcq_task.multiple_choice_qa)
+        clf._query_webapi_batch(["p2"], question=mcq_task.multiple_choice_qa)
+        clf._query_webapi_batch(["p3"], question=mcq_task.multiple_choice_qa)
+
+    matches = [
+        rec for rec in caplog.records
+        if "no validated entry" in rec.getMessage()
+    ]
+    assert len(matches) == 1
+
+
+def test_unvalidated_reasoning_warning_silent_for_non_reasoning_model(mcq_task, caplog):
+    """Models that don't advertise `reasoning_effort` must NOT trigger it."""
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(
+        cfg,
+        supported_params={"temperature", "max_tokens", "stream", "seed",
+                          "logprobs", "top_logprobs"},  # no reasoning_effort
+    )
+    clf._model_name = "gpt-4o-mini"
+
+    with caplog.at_level("WARNING"):
+        clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
+
+    matches = [
+        rec for rec in caplog.records
+        if "no validated entry" in rec.getMessage()
+    ]
+    assert matches == []
+
+
+def test_unvalidated_reasoning_warning_silent_for_validated_family(monkeypatch, mcq_task, caplog):
+    """gpt-5 (an explicitly-entered family) must NOT trigger the warning —
+    it's already validated and its quirks are applied automatically."""
+    from folktexts.classifier.web_api_classifier import (
+        _OPENAI_MODEL_FAMILY_QUIRKS,
+    )
+    cfg = PromptConfig.from_dict(pv={}, task=mcq_task)
+    clf, _ = _make_classifier(cfg)
+    clf._model_name = "gpt-5.4-nano"
+    # Simulate init having resolved the gpt-5 quirks (identity to module dict)
+    clf._family_quirks = _OPENAI_MODEL_FAMILY_QUIRKS["gpt-5"]
+
+    with caplog.at_level("WARNING"):
+        clf._query_webapi_batch(["p"], question=mcq_task.multiple_choice_qa)
+
+    matches = [
+        rec for rec in caplog.records
+        if "no validated entry" in rec.getMessage()
+    ]
+    assert matches == []
+
+
+def test_unvalidated_reasoning_warning_silent_for_cot(mcq_task, caplog):
+    """CoT reads free-form text and is robust to preambles — no warning."""
+    cfg = PromptConfig.from_dict(
+        pv={}, task=mcq_task, question=_cot_question(mcq_task),
+    )
+    clf, _ = _make_classifier(cfg)  # reasoning_effort in supported, default quirks
+    clf._model_name = "future-reasoning-model-vX"
+
+    with caplog.at_level("WARNING"):
+        clf._query_webapi_batch(["p"], question=_cot_question(mcq_task))
+
+    matches = [
+        rec for rec in caplog.records
+        if "no validated entry" in rec.getMessage()
+    ]
+    assert matches == []
+
+
 # --- Numeric percentage mode (gpt-5 workaround) -----------------------------
 
 def test_directnumericqa_percentage_prefix_has_no_decimal_prefill():
@@ -585,8 +683,8 @@ def test_enable_numeric_percentage_mode_swaps_question(mcq_task):
     assert new_q.num_forward_passes >= 10
     # `_encode_row` should now be a partial closed over the NEW config
     assert clf._encode_row.keywords["prompt_config"] is clf._prompt_config
-    # `_active_question` is the override the base classifier consults
-    assert clf._active_question is new_q
+    # The base classifier reads the swapped question from prompt_config.suffix
+    assert clf._prompt_config.suffix.question is new_q
 
 
 def test_enable_numeric_percentage_mode_installs_format_system_prompt(mcq_task):


### PR DESCRIPTION
## TL;DR
- Makes **gpt-5.x** work end-to-end on the WebAPI backend for all three question modes (`MultipleChoiceQA`, `DirectNumericQA`, `ChainOfThoughtQA`). Prior state: MCQ + Numeric crashed; only CoT worked.
- Fully transparent to callers — no CLI/config changes, other model families untouched, standard construction path is a no-op.
- Isolates gpt-5 quirks in a small typed table (`_OPENAI_MODEL_FAMILY_QUIRKS`, dataclass `_WebAPIQuirks`) in `web_api_classifier.py`; adds `DirectNumericQA(percentage=True)` mode auto-enabled for gpt-5 numeric runs.

## What was wrong (verified live against gpt-5.4-mini / -nano)

| Constraint | Failure mode | Fix |
|---|---|---|
| `top_logprobs > 5` | `BadRequestError: must be <= 5` | Clamp to family cap (5 for gpt-5; 20 elsewhere). |
| `logprobs` without `reasoning_effort='none'` | `UnsupportedParamsError` | Inject `reasoning_effort='none'` for MCQ/Numeric only (CoT keeps model's default). |
| ~3-token hidden preamble consumes `max_completion_tokens` even when `reasoning_tokens=0` | `max_tokens=1` → "could not finish"; numeric truncated | `max_tokens = num_forward_passes + overhead` (overhead 3 for gpt-5, 0 elsewhere). |
| Under `reasoning_effort='none'`, model collapses to `'0'` under `Answer: 0.` prefill | AUC ≈ 0.42 (chance) on `DirectNumericQA` | Reframe as integer percentage (`"Probability (0-100): "`, no decimal prefill) + format-only system prompt + anchor-based decoder on `probability<...>:`. |
| `reasoning_effort` is rejected by non-reasoning models | litellm errors on gpt-4o-mini | Send only when family quirks say so. |

## What this PR does

**`folktexts/classifier/web_api_classifier.py`**
- Adds `_OPENAI_MODEL_FAMILY_QUIRKS` (family-substring → `_WebAPIQuirks` frozen dataclass with four fields: `top_logprobs_max`, `max_tokens_overhead`, `force_reasoning_none`, `numeric_percentage_mode`) + `_resolve_family_quirks(model_name)` + `_DEFAULT_FAMILY_QUIRKS`. Substring match: `openai/gpt-5-turbo` and `gpt-5.4-nano` both resolve.
- Applies quirks at the two MCQ/Numeric call sites: `top_logprobs` clamp, `max_tokens` overhead, conditional `reasoning_effort='none'` (not for CoT).
- On `__init__`, auto-swaps `DirectNumericQA` → `DirectNumericQA(percentage=True, num_forward_passes=15)` when `numeric_percentage_mode` is set, and installs `NUMERIC_PERCENTAGE_SYSTEM_PROMPT` ("Reply with ONLY 'Probability (0-100): X%'; no preamble") — but only when the current system prompt is the QA subclass default (user-supplied `--system-prompt` is preserved).
- Emits a one-time `warnings.warn` when a model advertises reasoning support but has no validated `_WebAPIQuirks` entry.

**`folktexts/qa_interface.py`**
- New `DirectNumericQA.percentage: bool = False` field. `True` → `get_answer_prefix()` returns `"Probability (0-100): "` (no `0.` prefill); model replies with an integer in `[0, 100]`.
- New `_decode_percentage_expected_value` decoder: walks the argmax-per-position stream (`temperature=0` guarantees `chosen == argmax`), matches `re.compile(r"probability[^:]*:", re.IGNORECASE)`, returns mass-weighted expected value at the first post-anchor position with ≥0.1 numeric mass. Anchor deterministically skips the echoed range label `(0-100)` — its digits sit before the colon, so `[^:]*` stops before them. Falls back to 0.0 when no anchor is found (typically a preamble that ran out of budget).

**`folktexts/classifier/base.py`**
- Read active question via `self.prompt_config.suffix.question` rather than `self.task.question`, so backend-time subclass swaps reach the prediction path. No-op for standard construction (defaults are equal).

## Validation

End-to-end on gpt-5.4-nano, ACSIncome, n=100, seed 42:

| Mode | Accuracy | AUC | Brier |
|---|---:|---:|---:|
| MCQ (default) | 0.67 | **0.854** | 0.259 |
| CoT (`--cot-prompting`) | 0.69 | **0.840** | 0.187 |
| Numeric (`--numeric-risk-prompting`) | 0.61 | **0.863** | 0.220 |

Numeric progression during PR development: **0.42 → 0.803 → 0.863** (baseline crash → percentage-mode → + format-only system prompt; final: 0 fallbacks, 100 unique predictions).

### Tests
- 13 new unit tests covering the percentage-mode path (`tests/test_web_api_classifier.py`): prefix has no decimal prefill; decoder mass-weighted expected value; range-label digits skipped; paraphrased anchors accepted; no-anchor and no-digits fallbacks; decimal-mode regression guard; auto-swap installs format system prompt; user-supplied `system_prompt` preserved; MCQ / non-gpt-5 models don't get swapped.
- Full suite: **320 passed** locally (litellm-gated tests use `pytest.importorskip`). CI green across Python 3.8 → 3.12.

### Post-review cleanup
- `_WebAPIQuirks` typed dataclass replaces stringly-typed dict-of-dicts (typo-proof).
- 5 duplicated `isinstance(question, ChainOfThoughtQA)` checks consolidated to a single `is_cot` guard.
- MCQ vs. Numeric params-dict builders deduped; conditional `dataclasses.replace(...)` unified via `replace_kwargs`.
- Net **−27 lines** across 3 files.

### Rebase
- Rebased onto latest `main` (includes #40 batch prompt/tokenization) with no conflicts. All 320 tests still pass.