### PR TITLE
Batch prompt building and tokenization on the risk-score path

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -3,6 +3,14 @@
 Release notes summarising user-visible changes between versions. Older changes
 not yet listed here can be reconstructed from the git log.
 
+## v0.7.1 — batch prompt building and tokenization
+
+CPU-side speedups on the risk-score path; no observable output change (bit-identical predictions).
+
+- **Row materialization once per batch** in `LLMClassifier.compute_risk_estimates_for_dataframe`, avoiding `iterrows()` rebuilding row-Series on every question-permutation pass.
+- **Batched tokenizer call** in `query_model_batch` replaces the per-string `tokenizer.encode(...)` list-comp, letting fast (Rust) tokenizers thread-parallelize. Scales with batch size (~2.5× at `bs=128`).
+- Attention mask now sourced from the tokenizer rather than `tensor.ne(pad_token_id)` — correct even when `pad_token == eos_token` and a prompt legitimately contains EOS.
+
 ## v0.7.0 — consistent sampling temperature across backends
 
 Temperature is now a text-generation knob only, applied consistently across

--- a/folktexts/classifier/base.py
+++ b/folktexts/classifier/base.py
@@ -410,11 +410,16 @@ class LLMClassifier(BaseEstimator, ClassifierMixin, ABC):
             end_idx = min((batch_idx + 1) * batch_size, len(df))
             batch_data = df.iloc[start_idx:end_idx]
 
+            # Materialize row-Series once per batch; `iterrows()` rebuilds a
+            # Series (with dtype coercion) per row, and under order-bias
+            # correction the inner question loop iterates N_permutations times.
+            batch_rows = [row for _, row in batch_data.iterrows()]
+
             batch_risk_scores = np.empty((len(batch_data), len(questions)))
             for q_idx, q in enumerate(questions):
                 # Encode batch data into natural text prompts
                 data_texts_batch = [
-                    self.encode_row(row, question=q) for _, row in batch_data.iterrows()
+                    self.encode_row(row, question=q) for row in batch_rows
                 ]
 
                 # Query the model with the batch of data

--- a/folktexts/llm_utils.py
+++ b/folktexts/llm_utils.py
@@ -201,8 +201,10 @@ def query_model_batch(
 
     # Batched tokenization. `truncation_side="left"` reproduces the previous
     # per-row `[-context_size:]` semantics (keep the tail, drop the head);
-    # `padding_side="right"` matches the previous `pad_sequence` layout so the
-    # last-real-token index still comes from the pre-pad length. Restore both
+    # `padding_side="right"` is required by the last-token read below —
+    # `idx = attention_mask.sum(-1) - 1` points at the last real token only
+    # when pads sit AFTER the prompt (single forward pass, not `.generate()`,
+    # which uses left-padding in `generate_text_batch`). Restore both
     # attributes even if the tokenizer call raises.
     old_pad_side = tokenizer.padding_side
     old_trunc_side = tokenizer.truncation_side

--- a/folktexts/llm_utils.py
+++ b/folktexts/llm_utils.py
@@ -199,19 +199,34 @@ def query_model_batch(
     """
     model_device = next(model.parameters()).device
 
-    # Tokenize
-    token_inputs = [tokenizer.encode(text, return_tensors="pt").flatten()[-context_size:] for text in text_inputs]
-    idx_last_token = [tok_seq.shape[0] - 1 for tok_seq in token_inputs]
+    # Batched tokenization. `truncation_side="left"` reproduces the previous
+    # per-row `[-context_size:]` semantics (keep the tail, drop the head);
+    # `padding_side="right"` matches the previous `pad_sequence` layout so the
+    # last-real-token index still comes from the pre-pad length. Restore both
+    # attributes even if the tokenizer call raises.
+    old_pad_side = tokenizer.padding_side
+    old_trunc_side = tokenizer.truncation_side
+    tokenizer.padding_side = "right"
+    tokenizer.truncation_side = "left"
+    try:
+        tokenized = tokenizer(
+            text_inputs,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+            max_length=context_size,
+            add_special_tokens=True,
+        )
+    finally:
+        tokenizer.padding_side = old_pad_side
+        tokenizer.truncation_side = old_trunc_side
 
-    # Pad
-    tensor_inputs = torch.nn.utils.rnn.pad_sequence(
-        token_inputs,
-        batch_first=True,
-        padding_value=tokenizer.pad_token_id,
-    ).to(model_device)
-
-    # Mask padded context
-    attention_mask = tensor_inputs.ne(tokenizer.pad_token_id)
+    # Compute the last-real-token index on CPU before moving tensors to the
+    # model device, so the downstream `logits[torch.arange(...), idx]` gather
+    # uses plain Python ints and doesn't mix CPU/CUDA index tensors.
+    idx_last_token = (tokenized.attention_mask.sum(dim=1) - 1).tolist()
+    tensor_inputs = tokenized.input_ids.to(model_device)
+    attention_mask = tokenized.attention_mask.to(model_device)
 
     # Query: run one forward pass, i.e., generate the next token
     with torch.no_grad():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 
-version = "0.7.0"
+version = "0.7.1"
 requires-python = ">=3.8"
 dynamic = [
     "readme",

--- a/tests/test_classifier_pipeline.py
+++ b/tests/test_classifier_pipeline.py
@@ -194,6 +194,46 @@ class TestClassifierOrderBias:
 
         assert len(captured) == len(X_test)
 
+    def test_batch_path_prompts_match_series_path(self, clf, acs_income_dataset):
+        """The batch loop materializes rows once per batch instead of re-iterating
+        `batch_data.iterrows()` inside the per-question loop. This test guards the
+        byte-equality of the emitted prompts against a Series-per-row reference."""
+        X_test, _ = acs_income_dataset.get_test()
+
+        captured: list[tuple] = []  # (question, prompt)
+        original_encode_row = clf.encode_row
+
+        def capturing_encode_row(row, **kwargs):
+            prompt = original_encode_row(row, **kwargs)
+            captured.append((kwargs.get("question"), prompt))
+            return prompt
+
+        clf._encode_row = capturing_encode_row
+        try:
+            clf.predict_proba(X_test)
+        finally:
+            clf._encode_row = original_encode_row
+
+        # Two permutations under order-bias correction.
+        n_rows = len(X_test)
+        assert len(captured) == n_rows * 2
+
+        # Reference: encode each row directly with the classifier's encode_row,
+        # feeding pd.Series produced by df.iloc[i]. This mimics the pre-refactor
+        # path (Series per row) and must byte-match the batch path.
+        for perm_idx in range(2):
+            slice_start = perm_idx * n_rows
+            perm_captures = captured[slice_start:slice_start + n_rows]
+            # All prompts in this slice share the same question object.
+            question = perm_captures[0][0]
+            for i in range(n_rows):
+                q_captured, prompt_captured = perm_captures[i]
+                assert q_captured is question
+                prompt_ref = original_encode_row(X_test.iloc[i], question=question)
+                assert prompt_captured == prompt_ref, (
+                    f"Prompt mismatch at row {i}, permutation {perm_idx}"
+                )
+
 
 class TestClassifierConstruction:
     def test_rejects_removed_kwargs(self, tiny_model_and_tokenizer, acs_income_task):

--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -33,10 +33,19 @@ class _Tokenizer:
         for k in range(n_extra):
             self.vocab[f"<extra{k}>"] = vocab_size + k
         self.pad_token_id = 0
+        self.padding_side = "right"
+        self.truncation_side = "right"
 
     def encode(self, text, return_tensors=None):
         ids = torch.tensor([[1, 2, 3]], dtype=torch.long)
         return ids if return_tensors == "pt" else ids.tolist()
+
+    def __call__(self, texts, return_tensors=None, padding=None,
+                 truncation=None, max_length=None, add_special_tokens=None):
+        n = len(texts)
+        input_ids = torch.tensor([[1, 2, 3]] * n, dtype=torch.long)
+        attention_mask = torch.ones_like(input_ids)
+        return type("Enc", (), {"input_ids": input_ids, "attention_mask": attention_mask})()
 
     def decode(self, ids):
         return str(int(ids[0]))


### PR DESCRIPTION
## TL;DR

- **Fix A** — `LLMClassifier.compute_risk_estimates_for_dataframe`: materialize `batch_data.iterrows()` once per batch instead of re-iterating inside the per-question loop.
- **Fix B** — `query_model_batch`: replace per-string `tokenizer.encode(...)` list-comp with a single batched `tokenizer(...)` call so fast (Rust) tokenizers can thread-parallelize.
- No observable output change; predictions bit-identical to `origin/main` on Llama-3.2-3B/ACSIncome (832 and 3329 rows, max abs Δ = 0).
- Speedups (Python-only micro-bench): Fix A **1.09×** (scales with `N_permutations`); Fix B **1.22×** at `bs=8`, **2.48×** at `bs=128` (scales with batch size).
- E2E wall-clock on B200 is within noise at current model scale — GPU dominates. Larger batches / more permutations see the larger wins.

## Details

**Fix A** — under order-bias correction the inner question loop runs `N_permutations` times per batch, so `iterrows()` was rebuilding the same row-Series `N_permutations`× per batch. Now materialized once; every `encode_row_*` caller keeps receiving a `pd.Series` (no API-surface change).

**Fix B** — replaces the per-string encode loop with:

```python
tokenizer.padding_side = "right"      # matches previous pad_sequence layout
tokenizer.truncation_side = "left"    # reproduces previous `[-context_size:]` semantics
tokenized = tokenizer(text_inputs, return_tensors="pt", padding=True,
                      truncation=True, max_length=context_size, add_special_tokens=True)
```

Side effects, both intentional:
- `idx_last_token` is computed on CPU (plain Python ints) — same as before, just sourced from `attention_mask.sum(-1) - 1`.
- Attention mask now comes from the tokenizer instead of `tensor.ne(pad_token_id)` — the old mask silently zeroed any real token whose id equals `pad_token_id` (harmless on current call paths, broken in principle when `pad_token == eos_token` and a chat prompt legit contains EOS).

## Validation

- Unit tests: 285 → **286 passing** (adds `test_batch_path_prompts_match_series_path`, byte-equality guard between batch-path prompts and Series-per-row reference).
- E2E CLI on Llama-3.2-3B ACSIncome (transformers, subsampling 0.005 + 0.02) — bit-identical to `origin/main`.
- E2E CLI on vLLM (subsampling 0.005) — Fix A path only; predictions and `results.bench-*.json` hash-suffix unchanged.

Closes #28
